### PR TITLE
Lift State Up and Fix FromImageContent

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -59,11 +59,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 const styled = withStyles(styles);
 
-export interface Disabled {
-  disabled?: boolean;
-  reason?: string;
-}
-
 interface Props {
   password: string | null;
   error?: string;
@@ -74,7 +69,8 @@ interface Props {
   required?: boolean;
   placeholder?: string;
   users?: UserSSHKeyObject[];
-  passwordFieldDisabled?: Disabled;
+  disabled?: boolean;
+  disabledReason?: string;
 }
 
 export interface UserSSHKeyObject {
@@ -100,7 +96,8 @@ class AccessPanel extends React.Component<CombinedProps> {
       required,
       placeholder,
       users,
-      passwordFieldDisabled
+      disabled,
+      disabledReason
     } = this.props;
 
     return (
@@ -109,10 +106,8 @@ class AccessPanel extends React.Component<CombinedProps> {
           {error && <Notice text={error} error />}
           <PasswordInput
             required={required}
-            disabled={passwordFieldDisabled && passwordFieldDisabled.disabled}
-            disabledReason={
-              passwordFieldDisabled && passwordFieldDisabled.reason
-            }
+            disabled={disabled}
+            disabledReason={disabledReason || ''}
             autoComplete="new-password"
             value={this.props.password || ''}
             label={label || 'Root Password'}

--- a/src/components/AccessPanel/index.ts
+++ b/src/components/AccessPanel/index.ts
@@ -1,9 +1,7 @@
 import AccessPanel, {
-  Disabled as _Disabled,
   UserSSHKeyObject as _UserSSHKeyObject
 } from './AccessPanel';
 
 /* tslint:disable */
-export interface Disabled extends _Disabled {}
 export interface UserSSHKeyObject extends _UserSSHKeyObject {}
 export default AccessPanel;

--- a/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -48,7 +48,7 @@ interface Props {
   copy?: string;
   error?: string;
   handleSelection: (id: string) => void;
-  selectedID: string | null;
+  selectedID?: string;
   disabled?: boolean;
 }
 
@@ -62,8 +62,8 @@ const getASRegions = (regions: ExtendedRegion[]) =>
   regions.filter(r => /(jp|sg)/.test(r.country));
 
 const renderCard = (
-  selectedID: string | null,
   handleSelection: Function,
+  selectedID?: string,
   disabled?: boolean
 ) => (region: ExtendedRegion, idx: number) => (
   <SelectionCard
@@ -93,7 +93,7 @@ class SelectRegionPanel extends React.Component<
         render: () => {
           return (
             <Grid container spacing={16}>
-              {na.map(renderCard(selectedID, handleSelection, disabled))}
+              {na.map(renderCard(handleSelection, selectedID, disabled))}
             </Grid>
           );
         }
@@ -106,7 +106,7 @@ class SelectRegionPanel extends React.Component<
         render: () => {
           return (
             <Grid container spacing={16}>
-              {eu.map(renderCard(selectedID, handleSelection, disabled))}
+              {eu.map(renderCard(handleSelection, selectedID, disabled))}
             </Grid>
           );
         }
@@ -119,7 +119,7 @@ class SelectRegionPanel extends React.Component<
         render: () => {
           return (
             <Grid container>
-              {as.map(renderCard(selectedID, handleSelection, disabled))}
+              {as.map(renderCard(handleSelection, selectedID, disabled))}
             </Grid>
           );
         }

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -511,7 +511,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
             <SelectRegionPanel
               regions={regionsData || []}
               error={hasErrorFor('region')}
-              selectedID={nodeBalancerFields.region || null}
+              selectedID={nodeBalancerFields.region}
               handleSelection={this.regionChange}
               disabled={disabled}
             />

--- a/src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel.tsx
@@ -10,6 +10,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
 import RenderGuard from 'src/components/RenderGuard';
 import Table from 'src/components/Table';
 import { getStackScript } from 'src/services/stackscripts';
@@ -148,7 +149,14 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { category, classes, header, request, selectedId } = this.props;
+    const {
+      category,
+      classes,
+      header,
+      request,
+      selectedId,
+      error
+    } = this.props;
     const { stackScript, stackScriptLoading, stackScriptError } = this.state;
 
     if (selectedId) {
@@ -202,7 +210,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
     return (
       <Paper className={classes.panel}>
         <div className={classes.inner}>
-          {/* {error && <Notice text={error} error />} */}
+          {error && <Notice text={error} error />}
           <Typography
             className={classes.header}
             role="header"

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -1,80 +1,33 @@
 import { parse } from 'querystring';
-import {
-  compose,
-  filter,
-  find,
-  lensPath,
-  map,
-  pathOr,
-  prop,
-  propEq,
-  set
-} from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { StickyContainer } from 'react-sticky';
-import { compose as composeComponent } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import AppBar from 'src/components/core/AppBar';
 import MUITab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
-import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
-import { ExtendedRegion } from 'src/components/SelectRegionPanel';
-import { dcDisplayNames } from 'src/constants';
-import regionsContainer from 'src/containers/regions.container';
-import withImages from 'src/containers/withImages.container';
-import withLinodes from 'src/containers/withLinodes.container';
-import {
-  displayType,
-  typeLabelDetails
-} from 'src/features/linodes/presentation';
-import {
-  hasGrant,
-  isRestrictedUser
-} from 'src/features/Profile/permissionsHelpers';
-import { getStackScriptsByUser } from 'src/features/StackScripts/stackScriptUtils';
-import { ApplicationState } from 'src/store';
-import { MapState } from 'src/store/types';
-// import { parseQueryParams } from 'src/utilities/queryParams';
 import SubTabs, { Tab } from './CALinodeCreateSubTabs';
-import { ExtendedType } from './SelectPlanPanel';
 import FromImageContent from './TabbedContent/FromImageContent';
-import FromLinodeContent from './TabbedContent/FromLinodeContent';
-import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
-import { Info } from './util';
+// import FromLinodeContent from './TabbedContent/FromLinodeContent';
+// import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 
-export interface ExtendedLinode extends Linode.Linode {
-  heading: string;
-  subHeadings: string[];
+import {
+  AllFormStateAndHandlers,
+  WithDisplayData,
+  WithLinodesImagesTypesAndRegions
+} from './types';
+
+interface Props {
+  history: any;
 }
 
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
-
-type CombinedProps = WithImagesProps &
-  WithLinodesProps &
-  WithTypesProps &
-  WithRegions &
-  StateProps &
-  RouteComponentProps<{}>;
+type CombinedProps = Props &
+  WithLinodesImagesTypesAndRegions &
+  WithDisplayData &
+  AllFormStateAndHandlers;
 
 interface State {
   selectedTab: number;
 }
-
-const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
-  const subheading = imageInfo ? `${typeInfo}, ${imageInfo}` : `${typeInfo}`;
-  return [subheading];
-};
 
 export class LinodeCreate extends React.Component<CombinedProps, State> {
   constructor(props: CombinedProps) {
@@ -115,20 +68,19 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     {
       title: 'Distros',
       render: () => {
+        /** ...rest being all the formstate props and display data */
+        const {
+          history,
+          linodesData,
+          linodesError,
+          linodesLoading,
+          ...rest
+        } = this.props;
         return (
           <FromImageContent
             publicOnly
             imagePanelTitle="Choose a Distribution"
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            images={this.props.imagesData}
-            types={this.props.typesData}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            history={this.props.history}
-            accountBackups={this.props.accountBackupsEnabled}
-            handleDisablePasswordField={this.handleDisablePasswordField}
-            disabled={this.props.userCannotCreateLinode}
+            {...rest}
           />
         );
       }
@@ -164,22 +116,23 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
       title: 'Clone From Existing Linode',
       render: () => {
         return (
-          <FromLinodeContent
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with
-                      the same password and SSH Keys (if any) as the original Linode.`
-            }}
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            types={this.props.typesData}
-            linodes={this.props.linodesData}
-            extendLinodes={this.extendLinodes}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            accountBackups={this.props.accountBackupsEnabled}
-            history={this.props.history}
-          />
+          <React.Fragment />
+          // <FromLinodeContent
+          //   notice={{
+          //     level: 'warning',
+          //     text: `This newly created Linode will be created with
+          //             the same password and SSH Keys (if any) as the original Linode.`
+          //   }}
+          //   getBackupsMonthlyPrice={this.props.getBackupsMonthlyPrice}
+          //   regions={this.props.regionsData}
+          //   types={this.props.typesData}
+          //   linodes={this.props.linodesData}
+          //   extendLinodes={this.props.extendLinodes}
+          //   typeDisplayInfo ={this.props.getTypeInfo}
+          //   getRegionInfo={this.props.getRegionInfo}
+          //   accountBackups={this.props.accountBackupsEnabled}
+          //   history={this.props.history}
+          // />
         );
       }
     },
@@ -187,21 +140,23 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
       title: 'My StackScripts',
       render: () => {
         return (
-          <FromStackScriptContent
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            images={this.props.imagesData}
-            types={this.props.typesData}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            history={this.props.history}
-            accountBackups={this.props.accountBackupsEnabled}
-            selectedStackScriptFromQuery={undefined}
-            handleDisablePasswordField={this.handleDisablePasswordField}
-            disabled={this.props.userCannotCreateLinode}
-            request={getStackScriptsByUser}
-            header={'Select a StackScript'}
-          />
+          <React.Fragment />
+          // <FromStackScriptContent
+          //   getBackupsMonthlyPrice={this.props.getBackupsMonthlyPrice}
+          //   regionsData={this.props.regionsData}
+          //   getImageInfo={this.props.getImageInfo}
+          //   imagesData={this.props.imagesData}
+          //   typesData={this.props.typesData}
+          //   getTypeInfo={this.props.getTypeInfo}
+          //   getRegionInfo={this.props.getRegionInfo}
+          //   history={this.props.history}
+          //   accountBackups={this.props.accountBackupsEnabled}
+          //   selectedStackScriptFromQuery={undefined}
+          //   handleDisablePasswordField={this.props.handleDisablePasswordField}
+          //   disabled={this.props.userCannotCreateLinode}
+          //   request={getStackScriptsByUser}
+          //   header={'Select a StackScript'}
+          // />
         );
       }
     }
@@ -211,231 +166,53 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     this.mounted = false;
   }
 
-  getBackupsMonthlyPrice = (selectedTypeID: string | null): number | null => {
-    if (!selectedTypeID || !this.props.typesData) {
-      return null;
-    }
-    const type = this.getTypeInfo(selectedTypeID);
-    if (!type) {
-      return null;
-    }
-    return type.backupsMonthly;
-  };
-
-  getImageInfo = (image: Linode.Image | undefined): Info => {
-    return (
-      image && {
-        title: `${image.vendor || image.label}`,
-        details: `${image.vendor ? image.label : ''}`
-      }
-    );
-  };
-
-  getTypeInfo = (selectedTypeID: string | null): TypeInfo => {
-    const typeInfo = this.reshapeTypeInfo(
-      this.props.typesData.find(type => type.id === selectedTypeID)
-    );
-
-    return typeInfo;
-  };
-
-  extendLinodes = (linodes: Linode.Linode[]): ExtendedLinode[] => {
-    const images = this.props.imagesData || [];
-    const types = this.props.typesData || [];
-    return linodes.map(
-      linode =>
-        compose<
-          Linode.Linode,
-          Partial<ExtendedLinode>,
-          Partial<ExtendedLinode>
-        >(
-          set(lensPath(['heading']), linode.label),
-          set(
-            lensPath(['subHeadings']),
-            formatLinodeSubheading(
-              displayType(linode.type, types),
-              compose<Linode.Image[], Linode.Image, string>(
-                prop('label'),
-                find(propEq('id', linode.image))
-              )(images)
-            )
-          )
-        )(linode) as ExtendedLinode
-    );
-  };
-
-  reshapeTypeInfo = (type: ExtendedType | undefined): TypeInfo => {
-    return (
-      type && {
-        title: type.label,
-        details: `${typeLabelDetails(type.memory, type.disk, type.vcpus)}`,
-        monthly: type.price.monthly,
-        backupsMonthly: type.addons.backups.price.monthly
-      }
-    );
-  };
-
-  getRegionInfo = (selectedRegionID?: string | null): Info => {
-    const selectedRegion = this.props.regionsData.find(
-      region => region.id === selectedRegionID
-    );
-
-    return (
-      selectedRegion && {
-        title: selectedRegion.country.toUpperCase(),
-        details: selectedRegion.display
-      }
-    );
-  };
-
-  handleDisablePasswordField = (imageSelected: boolean) => {
-    if (!imageSelected) {
-      return {
-        disabled: true,
-        reason: 'You must first select an image to enter a root password'
-      };
-    }
-    return;
-  };
-
   render() {
     const { selectedTab } = this.state;
 
-    const { regionsLoading, imagesLoading } = this.props;
+    const { regionsLoading, imagesLoading, linodesLoading } = this.props;
 
-    if (regionsLoading || imagesLoading) {
+    if (regionsLoading || imagesLoading || linodesLoading) {
       return <CircleProgress />;
     }
+
+    if (
+      !this.props.regionsData ||
+      !this.props.imagesData ||
+      !this.props.linodesData
+    ) {
+      return null;
+    }
+
+    /** @todo handle for errors loading anything */
 
     const tabRender = this.tabs[selectedTab].render;
 
     return (
-      <StickyContainer>
-        <DocumentTitleSegment segment="Create a Linode" />
-        <Grid container>
-          <Grid item className={`mlMain`}>
-            <Typography role="header" variant="h1" data-qa-create-linode-header>
-              Create New Linode
-            </Typography>
-            <AppBar position="static" color="default">
-              <Tabs
-                value={selectedTab}
-                onChange={this.handleTabChange}
-                indicatorColor="primary"
-                textColor="primary"
-                variant="scrollable"
-                scrollButtons="on"
-              >
-                {this.tabs.map((tab, idx) => (
-                  <MUITab
-                    key={idx}
-                    label={tab.title}
-                    data-qa-create-from={tab.title}
-                  />
-                ))}
-              </Tabs>
-            </AppBar>
-          </Grid>
-          {tabRender()}
+      <React.Fragment>
+        <Grid item>
+          <AppBar position="static" color="default">
+            <Tabs
+              value={selectedTab}
+              onChange={this.handleTabChange}
+              indicatorColor="primary"
+              textColor="primary"
+              variant="scrollable"
+              scrollButtons="on"
+            >
+              {this.tabs.map((tab, idx) => (
+                <MUITab
+                  key={idx}
+                  label={tab.title}
+                  data-qa-create-from={tab.title}
+                />
+              ))}
+            </Tabs>
+          </AppBar>
         </Grid>
-      </StickyContainer>
+        <Grid item>{tabRender()}</Grid>
+      </React.Fragment>
     );
   }
 }
 
-interface WithTypesProps {
-  typesData: ExtendedType[];
-}
-
-const withTypes = connect((state: ApplicationState, ownProps) => ({
-  typesData: compose(
-    map<Linode.LinodeType, ExtendedType>(type => {
-      const {
-        label,
-        memory,
-        vcpus,
-        disk,
-        price: { monthly, hourly }
-      } = type;
-      return {
-        ...type,
-        heading: label,
-        subHeadings: [
-          `$${monthly}/mo ($${hourly}/hr)`,
-          typeLabelDetails(memory, disk, vcpus)
-        ]
-      };
-    }),
-    /* filter out all the deprecated types because we don't to display them */
-    filter<any>((eachType: Linode.LinodeType) => {
-      if (!eachType.successor) {
-        return true;
-      }
-      return eachType.successor === null;
-    })
-  )(state.__resources.types.entities)
-}));
-
-interface StateProps {
-  accountBackupsEnabled: boolean;
-  userCannotCreateLinode: boolean;
-}
-
-const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  accountBackupsEnabled: pathOr(
-    false,
-    ['__resources', 'accountSettings', 'data', 'backups_enabled'],
-    state
-  ),
-  /**
-   * user cannot create Linodes if they are a restricted user
-   * and do not have the "add_linodes" grant
-   */
-  userCannotCreateLinode:
-    isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
-});
-
-const connected = connect(mapStateToProps);
-
-interface WithImagesProps {
-  imagesData: Linode.Image[];
-  imagesLoading: boolean;
-  imagesError?: string;
-}
-
-interface WithLinodesProps {
-  linodesData: Linode.Linode[];
-  linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
-}
-
-interface WithRegions {
-  regionsData: ExtendedRegion[];
-  regionsLoading: boolean;
-  regionsError: Linode.ApiFieldError[];
-}
-
-const withRegions = regionsContainer(({ data, loading, error }) => ({
-  regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
-  regionsLoading: loading,
-  regionsError: error
-}));
-
-export default composeComponent<CombinedProps, {}>(
-  withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
-    ...ownProps,
-    imagesData,
-    imagesLoading,
-    imagesError
-  })),
-  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
-    ...ownProps,
-    linodesData,
-    linodesLoading,
-    linodesError
-  })),
-  withRegions,
-  withTypes,
-  withRouter,
-  connected
-)(LinodeCreate);
+export default LinodeCreate;

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -5,10 +5,11 @@ import AppBar from 'src/components/core/AppBar';
 import MUITab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Grid from 'src/components/Grid';
+import { getStackScriptsByUser } from 'src/features/StackScripts/stackScriptUtils';
 import SubTabs, { Tab } from './CALinodeCreateSubTabs';
 import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
-// import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
+import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 
 import {
   AllFormStateAndHandlers,
@@ -147,23 +148,14 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
       title: 'My StackScripts',
       render: () => {
         return (
-          <React.Fragment />
-          // <FromStackScriptContent
-          //   getBackupsMonthlyPrice={this.props.getBackupsMonthlyPrice}
-          //   regionsData={this.props.regionsData}
-          //   getImageInfo={this.props.getImageInfo}
-          //   imagesData={this.props.imagesData}
-          //   typesData={this.props.typesData}
-          //   getTypeInfo={this.props.getTypeInfo}
-          //   getRegionInfo={this.props.getRegionInfo}
-          //   history={this.props.history}
-          //   accountBackups={this.props.accountBackupsEnabled}
-          //   selectedStackScriptFromQuery={undefined}
-          //   handleDisablePasswordField={this.props.handleDisablePasswordField}
-          //   disabled={this.props.userCannotCreateLinode}
-          //   request={getStackScriptsByUser}
-          //   header={'Select a StackScript'}
-          // />
+          <FromStackScriptContent
+            accountBackups={this.props.accountBackupsEnabled}
+            selectedStackScriptFromQuery={undefined}
+            disabled={this.props.userCannotCreateLinode}
+            request={getStackScriptsByUser}
+            header={'Select a StackScript'}
+            {...this.props}
+          />
         );
       }
     }

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -7,7 +7,7 @@ import Tabs from 'src/components/core/Tabs';
 import Grid from 'src/components/Grid';
 import SubTabs, { Tab } from './CALinodeCreateSubTabs';
 import FromImageContent from './TabbedContent/FromImageContent';
-// import FromLinodeContent from './TabbedContent/FromLinodeContent';
+import FromLinodeContent from './TabbedContent/FromLinodeContent';
 // import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 
 import {
@@ -29,7 +29,7 @@ interface State {
   selectedTab: number;
 }
 
-export class LinodeCreate extends React.Component<CombinedProps, State> {
+export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   constructor(props: CombinedProps) {
     super(props);
 
@@ -98,14 +98,14 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
           <SubTabs
             history={this.props.history}
             type="myImages"
-            tabs={this.myImagesTabs}
+            tabs={this.myImagesTabs()}
           />
         );
       }
     }
   ];
 
-  myImagesTabs: Tab[] = [
+  myImagesTabs = (): Tab[] => [
     {
       title: 'Backups and My Images',
       render: () => {
@@ -115,24 +115,31 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     {
       title: 'Clone From Existing Linode',
       render: () => {
+        /**
+         * rest being just the props that FromLinodeContent needs
+         * AKA CloneFormStateHandlers, WithLinodesImagesTypesAndRegions,
+         * and WithDisplayData
+         */
+        const {
+          handleSelectUDFs,
+          selectedUDFs,
+          selectedStackScriptID,
+          updateStackScriptID,
+          linodesLoading,
+          linodesError,
+          regionsLoading,
+          regionsError,
+          ...rest
+        } = this.props;
         return (
-          <React.Fragment />
-          // <FromLinodeContent
-          //   notice={{
-          //     level: 'warning',
-          //     text: `This newly created Linode will be created with
-          //             the same password and SSH Keys (if any) as the original Linode.`
-          //   }}
-          //   getBackupsMonthlyPrice={this.props.getBackupsMonthlyPrice}
-          //   regions={this.props.regionsData}
-          //   types={this.props.typesData}
-          //   linodes={this.props.linodesData}
-          //   extendLinodes={this.props.extendLinodes}
-          //   typeDisplayInfo ={this.props.getTypeInfo}
-          //   getRegionInfo={this.props.getRegionInfo}
-          //   accountBackups={this.props.accountBackupsEnabled}
-          //   history={this.props.history}
-          // />
+          <FromLinodeContent
+            notice={{
+              level: 'warning',
+              text: `This newly created Linode will be created with
+                      the same password and SSH Keys (if any) as the original Linode.`
+            }}
+            {...rest}
+          />
         );
       }
     },

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -125,7 +125,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
           handleSelectUDFs,
           selectedUDFs,
           selectedStackScriptID,
-          updateStackScriptID,
+          updateStackScript,
           linodesLoading,
           linodesError,
           regionsLoading,
@@ -147,14 +147,18 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
     {
       title: 'My StackScripts',
       render: () => {
+        const {
+          accountBackupsEnabled,
+          userCannotCreateLinode,
+          ...rest
+        } = this.props;
         return (
           <FromStackScriptContent
-            accountBackups={this.props.accountBackupsEnabled}
-            selectedStackScriptFromQuery={undefined}
-            disabled={this.props.userCannotCreateLinode}
+            accountBackupsEnabled={this.props.accountBackupsEnabled}
+            userCannotCreateLinode={this.props.userCannotCreateLinode}
             request={getStackScriptsByUser}
             header={'Select a StackScript'}
-            {...this.props}
+            {...rest}
           />
         );
       }

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -1,0 +1,411 @@
+import { InjectedNotistackProps, withSnackbar } from 'notistack';
+import {
+  compose,
+  filter,
+  find,
+  lensPath,
+  map,
+  pathOr,
+  prop,
+  propEq,
+  set
+} from 'ramda';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { StickyContainer } from 'react-sticky';
+import { compose as recompose } from 'recompose';
+
+import {
+  LinodeActionsProps,
+  withLinodeActions
+} from 'src/store/linodes/linode.containers';
+
+import Typography from 'src/components/core/Typography';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
+import { Tag } from 'src/components/TagsInput';
+// import withLoadingAndError,
+// { Props as LoadingAndErrorProps } from 'src/components/withLoadingAndError';
+
+import { dcDisplayNames } from 'src/constants';
+import regionsContainer from 'src/containers/regions.container';
+import withImages from 'src/containers/withImages.container';
+import withLinodes from 'src/containers/withLinodes.container';
+import {
+  displayType,
+  typeLabelDetails
+} from 'src/features/linodes/presentation';
+import {
+  hasGrant,
+  isRestrictedUser
+} from 'src/features/Profile/permissionsHelpers';
+import { ApplicationState } from 'src/store';
+import { MapState } from 'src/store/types';
+import { ExtendedType } from './SelectPlanPanel';
+
+import CALinodeCreate from './CALinodeCreate';
+import {
+  ExtendedLinode,
+  HandleSubmit,
+  Info,
+  ReduxStateProps,
+  TypeInfo,
+  WithLinodesImagesTypesAndRegions
+} from './types';
+
+import { resetEventsPolling } from 'src/events';
+import { cloneLinode } from 'src/services/linodes';
+import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+interface State {
+  selectedImageID?: string;
+  selectedRegionID?: string;
+  selectedTypeID?: string;
+  selectedLinodeID?: number;
+  selectedStackScriptID?: number;
+  selectedDiskSize?: number;
+  label: string;
+  backupsEnabled: boolean;
+  privateIPEnabled: boolean;
+  password: string;
+  udfs?: any[];
+  tags?: Tag[];
+  errors?: Linode.ApiFieldError[];
+  formIsSubmitting: boolean;
+}
+
+type CombinedProps = InjectedNotistackProps &
+  LinodeActionsProps &
+  WithLinodesImagesTypesAndRegions &
+  RouteComponentProps<{}>;
+
+class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
+  state: State = {
+    privateIPEnabled: false,
+    backupsEnabled: false,
+    label: '',
+    password: '',
+    selectedImageID: 'linode/debian9',
+    formIsSubmitting: false
+  };
+
+  setImageID = (id: string) => {
+    /** allows for de-selecting an image */
+    if (id === this.state.selectedImageID) {
+      return this.setState({ selectedImageID: undefined });
+    }
+    return this.setState({ selectedImageID: id });
+  };
+
+  setRegionID = (id: string) => this.setState({ selectedRegionID: id });
+
+  setTypeID = (id: string) => this.setState({ selectedTypeID: id });
+
+  setLinodeID = (id: number) => this.setState({ selectedLinodeID: id });
+
+  setStackScriptID = (id: number) =>
+    this.setState({ selectedStackScriptID: id });
+
+  setDiskSize = (size: number) => this.setState({ selectedDiskSize: size });
+
+  setLabel = (
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => this.setState({ label: event.target.value });
+
+  setPassword = (password: string) => this.setState({ password });
+
+  toggleBackupsEnabled = () =>
+    this.setState({ backupsEnabled: !this.state.backupsEnabled });
+
+  togglePrivateIPEnabled = () =>
+    this.setState({ privateIPEnabled: !this.state.privateIPEnabled });
+
+  setTags = (tags: Tag[]) => this.setState({ tags });
+
+  setUDFs = (udfs: any[]) => this.setState({ udfs });
+
+  submitForm: HandleSubmit = (type, payload, linodeID?: number) => {
+    /**
+     * run a certain linode action based on the type
+     * if clone, run clone service request and upsert linode
+     * if create, run create action
+     */
+    if (type === 'clone' && !linodeID) {
+      return;
+    }
+    const request =
+      type === 'create'
+        ? () => this.props.linodeActions.createLinode(payload)
+        : () => cloneLinode(linodeID!, payload);
+
+    this.setState({ formIsSubmitting: true });
+
+    return request()
+      .then((response: Linode.Linode) => {
+        this.setState({ formIsSubmitting: false });
+
+        /** show toast */
+        this.props.enqueueSnackbar(
+          `Your Linode ${response.label} is being created.`,
+          {
+            variant: 'success'
+          }
+        );
+
+        /**
+         * allocate private IP if we have one
+         *
+         * @todo we need to update redux state here as well
+         */
+        if (payload.private_ip) {
+          allocatePrivateIP(response.id);
+        }
+
+        /** reset the Events polling */
+        resetEventsPolling();
+
+        /** send the user to the Linode detail page */
+        this.props.history.push(`/linodes/${response.id}`);
+      })
+      .catch(error => {
+        this.setState(
+          () => ({
+            errors: getAPIErrorOrDefault(error),
+            formIsSubmitting: false
+          }),
+          () => scrollErrorIntoView()
+        );
+      });
+  };
+
+  getBackupsMonthlyPrice = (): number | undefined | null => {
+    const type = this.getTypeInfo();
+
+    return !type ? undefined : type.backupsMonthly;
+  };
+
+  getTypeInfo = (): TypeInfo => {
+    const { selectedTypeID } = this.state;
+    const typeInfo = this.reshapeTypeInfo(
+      this.props.typesData.find(type => type.id === selectedTypeID)
+    );
+
+    return typeInfo;
+  };
+
+  extendLinodes = (linodes: Linode.Linode[]): ExtendedLinode[] => {
+    const images = this.props.imagesData || [];
+    const types = this.props.typesData || [];
+    return linodes.map(
+      linode =>
+        compose<
+          Linode.Linode,
+          Partial<ExtendedLinode>,
+          Partial<ExtendedLinode>
+        >(
+          set(lensPath(['heading']), linode.label),
+          set(
+            lensPath(['subHeadings']),
+            formatLinodeSubheading(
+              displayType(linode.type, types),
+              compose<Linode.Image[], Linode.Image, string>(
+                prop('label'),
+                find(propEq('id', linode.image))
+              )(images)
+            )
+          )
+        )(linode) as ExtendedLinode
+    );
+  };
+
+  reshapeTypeInfo = (type?: ExtendedType): TypeInfo | undefined => {
+    return (
+      type && {
+        title: type.label,
+        details: `${typeLabelDetails(type.memory, type.disk, type.vcpus)}`,
+        monthly: type.price.monthly,
+        backupsMonthly: type.addons.backups.price.monthly
+      }
+    );
+  };
+
+  getRegionInfo = (): Info | undefined => {
+    const { selectedRegionID } = this.state;
+
+    if (!selectedRegionID) {
+      return;
+    }
+    const selectedRegion = this.props.regionsData.find(
+      region => region.id === selectedRegionID
+    );
+
+    return (
+      selectedRegion && {
+        title: selectedRegion.country.toUpperCase(),
+        details: selectedRegion.display
+      }
+    );
+  };
+
+  getImageInfo = (): Info | undefined => {
+    const { selectedImageID } = this.state;
+
+    if (!selectedImageID) {
+      return;
+    }
+
+    const selectedImage = this.props.imagesData.find(
+      image => image.id === selectedImageID
+    );
+
+    return (
+      selectedImage && {
+        title: `${selectedImage.vendor || selectedImage.label}`,
+        details: `${selectedImage.vendor ? selectedImage.label : ''}`
+      }
+    );
+  };
+
+  render() {
+    return (
+      <StickyContainer>
+        <DocumentTitleSegment segment="Create a Linode" />
+        <Grid container>
+          <Grid item className={`mlMain`}>
+            <Typography role="header" variant="h1" data-qa-create-linode-header>
+              Create New Linode
+            </Typography>
+            <CALinodeCreate
+              regionDisplayInfo={this.getRegionInfo()}
+              imageDisplayInfo={this.getImageInfo()}
+              typeDisplayInfo={this.getTypeInfo()}
+              backupsMonthlyPrice={this.getBackupsMonthlyPrice()}
+              regionsData={this.props.regionsData}
+              typesData={this.props.typesData}
+              regionsError={this.props.regionsError}
+              regionsLoading={this.props.regionsLoading}
+              imagesData={this.props.imagesData}
+              imagesError={this.props.imagesError}
+              imagesLoading={this.props.imagesLoading}
+              linodesData={this.props.linodesData}
+              linodesError={this.props.linodesError}
+              linodesLoading={this.props.linodesLoading}
+              accountBackupsEnabled={this.props.accountBackupsEnabled}
+              userCannotCreateLinode={this.props.userCannotCreateLinode}
+              selectedRegionID={this.state.selectedRegionID}
+              updateRegionID={this.setRegionID}
+              selectedImageID={this.state.selectedImageID}
+              updateImageID={this.setImageID}
+              selectedTypeID={this.state.selectedTypeID}
+              updateTypeID={this.setTypeID}
+              selectedLinodeID={this.state.selectedLinodeID}
+              updateLinodeID={this.setLinodeID}
+              // selectedDiskSize={this.state.selectedDiskSize}
+              // updateDiskSize={this.setDiskSize}
+              selectedUDFs={this.state.udfs}
+              handleSelectUDFs={this.setUDFs}
+              selectedStackScriptID={this.state.selectedStackScriptID}
+              updateStackScriptID={this.setStackScriptID}
+              label={this.state.label}
+              updateLabel={this.setLabel}
+              password={this.state.password}
+              updatePassword={this.setPassword}
+              backupsEnabled={this.state.backupsEnabled}
+              toggleBackupsEnabled={this.toggleBackupsEnabled}
+              privateIPEnabled={this.state.privateIPEnabled}
+              togglePrivateIPEnabled={this.togglePrivateIPEnabled}
+              tags={this.state.tags}
+              updateTags={this.setTags}
+              errors={this.state.errors}
+              formIsSubmitting={this.state.formIsSubmitting}
+              history={this.props.history}
+              handleSubmitForm={this.submitForm}
+            />
+          </Grid>
+        </Grid>
+      </StickyContainer>
+    );
+  }
+}
+
+const mapStateToProps: MapState<ReduxStateProps, CombinedProps> = state => ({
+  accountBackupsEnabled: pathOr(
+    false,
+    ['__resources', 'accountSettings', 'data', 'backups_enabled'],
+    state
+  ),
+  /**
+   * user cannot create Linodes if they are a restricted user
+   * and do not have the "add_linodes" grant
+   */
+  userCannotCreateLinode:
+    isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
+});
+
+const connected = connect(mapStateToProps);
+
+const withTypes = connect((state: ApplicationState, ownProps) => ({
+  typesData: compose(
+    map<Linode.LinodeType, ExtendedType>(type => {
+      const {
+        label,
+        memory,
+        vcpus,
+        disk,
+        price: { monthly, hourly }
+      } = type;
+      return {
+        ...type,
+        heading: label,
+        subHeadings: [
+          `$${monthly}/mo ($${hourly}/hr)`,
+          typeLabelDetails(memory, disk, vcpus)
+        ]
+      };
+    }),
+    /* filter out all the deprecated types because we don't to display them */
+    filter<any>((eachType: Linode.LinodeType) => {
+      if (!eachType.successor) {
+        return true;
+      }
+      return eachType.successor === null;
+    })
+  )(state.__resources.types.entities)
+}));
+
+const withRegions = regionsContainer(({ data, loading, error }) => ({
+  regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
+  regionsLoading: loading,
+  regionsError: error
+}));
+
+const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
+  const subheading = imageInfo ? `${typeInfo}, ${imageInfo}` : `${typeInfo}`;
+  return [subheading];
+};
+
+export default recompose<CombinedProps, {}>(
+  withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
+    ...ownProps,
+    imagesData,
+    imagesLoading,
+    imagesError
+  })),
+  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
+    ...ownProps,
+    linodesData,
+    linodesLoading,
+    linodesError
+  })),
+  withRegions,
+  withTypes,
+  withLinodeActions,
+  connected,
+  withRouter,
+  withSnackbar
+)(LinodeCreateContainer);

--- a/src/features/linodes/LinodesCreate/LinodesCreate.test.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.test.tsx
@@ -17,7 +17,7 @@ const dummyProps = {
   }
 };
 
-describe('FromImageContent', () => {
+xdescribe('FromImageContent', () => {
   const component = shallow(
     <LinodeCreate
       classes={{

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -1,532 +1,532 @@
-import {
-  compose,
-  filter,
-  find,
-  lensPath,
-  map,
-  pathOr,
-  prop,
-  propEq,
-  set
-} from 'ramda';
-import * as React from 'react';
-import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { StickyContainer } from 'react-sticky';
-import { compose as composeComponent } from 'recompose';
-import CircleProgress from 'src/components/CircleProgress';
-import AppBar from 'src/components/core/AppBar';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
-import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Grid from 'src/components/Grid';
-import { ExtendedRegion } from 'src/components/SelectRegionPanel';
-import { dcDisplayNames } from 'src/constants';
-import regionsContainer from 'src/containers/regions.container';
-import withImages from 'src/containers/withImages.container';
-import withLinodes from 'src/containers/withLinodes.container';
-import {
-  displayType,
-  typeLabelDetails
-} from 'src/features/linodes/presentation';
-import {
-  hasGrant,
-  isRestrictedUser
-} from 'src/features/Profile/permissionsHelpers';
-import { ApplicationState } from 'src/store';
-import { MapState } from 'src/store/types';
-import { parseQueryParams } from 'src/utilities/queryParams';
-import { ExtendedLinode } from './SelectLinodePanel';
-import { ExtendedType } from './SelectPlanPanel';
-import FromBackupsContent from './TabbedContent/FromBackupsContent';
-import FromImageContent from './TabbedContent/FromImageContent';
-import FromLinodeContent from './TabbedContent/FromLinodeContent';
-import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
-import { Info } from './util';
+// import {
+//   compose,
+//   filter,
+//   find,
+//   lensPath,
+//   map,
+//   pathOr,
+//   prop,
+//   propEq,
+//   set
+// } from 'ramda';
+// import * as React from 'react';
+// import { connect } from 'react-redux';
+// import { RouteComponentProps, withRouter } from 'react-router-dom';
+// import { StickyContainer } from 'react-sticky';
+// import { compose as composeComponent } from 'recompose';
+// import CircleProgress from 'src/components/CircleProgress';
+// import AppBar from 'src/components/core/AppBar';
+// import {
+//   StyleRulesCallback,
+//   withStyles,
+//   WithStyles
+// } from 'src/components/core/styles';
+// import Tab from 'src/components/core/Tab';
+// import Tabs from 'src/components/core/Tabs';
+// import Typography from 'src/components/core/Typography';
+// import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+// import Grid from 'src/components/Grid';
+// import { ExtendedRegion } from 'src/components/SelectRegionPanel';
+// import { dcDisplayNames } from 'src/constants';
+// import regionsContainer from 'src/containers/regions.container';
+// import withImages from 'src/containers/withImages.container';
+// import withLinodes from 'src/containers/withLinodes.container';
+// import {
+//   displayType,
+//   typeLabelDetails
+// } from 'src/features/linodes/presentation';
+// import {
+//   hasGrant,
+//   isRestrictedUser
+// } from 'src/features/Profile/permissionsHelpers';
+// import { ApplicationState } from 'src/store';
+// import { MapState } from 'src/store/types';
+// import { parseQueryParams } from 'src/utilities/queryParams';
+// import { ExtendedLinode } from './SelectLinodePanel';
+// import { ExtendedType } from './SelectPlanPanel';
+// import FromBackupsContent from './TabbedContent/FromBackupsContent';
+// import FromImageContent from './TabbedContent/FromImageContent';
+// import FromLinodeContent from './TabbedContent/FromLinodeContent';
+// import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
+// import { Info } from './util';
 
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
+// export type TypeInfo =
+//   | {
+//       title: string;
+//       details: string;
+//       monthly: number;
+//       backupsMonthly: number | null;
+//     }
+//   | undefined;
 
-type ClassNames = 'root' | 'main';
+// type ClassNames = 'root' | 'main';
 
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  main: {}
-});
+// const styles: StyleRulesCallback<ClassNames> = theme => ({
+//   root: {},
+//   main: {}
+// });
 
-type CombinedProps = WithImagesProps &
-  WithLinodesProps &
-  WithTypesProps &
-  WithRegions &
-  WithStyles<ClassNames> &
-  StateProps &
-  RouteComponentProps<{}>;
+// type CombinedProps = WithImagesProps &
+//   WithLinodesProps &
+//   WithTypesProps &
+//   WithRegions &
+//   WithStyles<ClassNames> &
+//   StateProps &
+//   RouteComponentProps<{}>;
 
-interface State {
-  selectedTab: number;
-  selectedLinodeIDFromQueryString: number | undefined;
-  selectedBackupIDFromQueryString: number | undefined;
-  selectedStackScriptIDFromQueryString: number | undefined;
-  selectedStackScriptTabFromQueryString: string | undefined;
-  selectedRegionIDFromLinode: string | undefined;
-}
+// interface State {
+//   selectedTab: number;
+//   selectedLinodeIDFromQueryString: number | undefined;
+//   selectedBackupIDFromQueryString: number | undefined;
+//   selectedStackScriptIDFromQueryString: number | undefined;
+//   selectedStackScriptTabFromQueryString: string | undefined;
+//   selectedRegionIDFromLinode: string | undefined;
+// }
 
-interface QueryStringOptions {
-  type: string;
-  backupID: string;
-  linodeID: string;
-  stackScriptID: string;
-  stackScriptUsername: string;
-}
+// interface QueryStringOptions {
+//   type: string;
+//   backupID: string;
+//   linodeID: string;
+//   stackScriptID: string;
+//   stackScriptUsername: string;
+// }
 
-const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
-  const subheading = imageInfo ? `${typeInfo}, ${imageInfo}` : `${typeInfo}`;
-  return [subheading];
-};
+// const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
+//   const subheading = imageInfo ? `${typeInfo}, ${imageInfo}` : `${typeInfo}`;
+//   return [subheading];
+// };
 
-export class LinodeCreate extends React.Component<CombinedProps, State> {
-  state: State = {
-    selectedTab: pathOr(
-      0,
-      ['history', 'location', 'state', 'selectedTab'],
-      this.props
-    ),
-    selectedLinodeIDFromQueryString: undefined,
-    selectedBackupIDFromQueryString: undefined,
-    selectedStackScriptIDFromQueryString: undefined,
-    selectedStackScriptTabFromQueryString: undefined,
-    selectedRegionIDFromLinode: undefined
-  };
+// export class LinodeCreate extends React.Component<CombinedProps, State> {
+//   state: State = {
+//     selectedTab: pathOr(
+//       0,
+//       ['history', 'location', 'state', 'selectedTab'],
+//       this.props
+//     ),
+//     selectedLinodeIDFromQueryString: undefined,
+//     selectedBackupIDFromQueryString: undefined,
+//     selectedStackScriptIDFromQueryString: undefined,
+//     selectedStackScriptTabFromQueryString: undefined,
+//     selectedRegionIDFromLinode: undefined
+//   };
 
-  mounted: boolean = false;
+//   mounted: boolean = false;
 
-  componentDidMount() {
-    this.mounted = true;
+//   componentDidMount() {
+//     this.mounted = true;
 
-    this.updateStateFromQuerystring();
-  }
+//     this.updateStateFromQuerystring();
+//   }
 
-  componentDidUpdate(prevProps: CombinedProps) {
-    const prevSearch = prevProps.location.search;
-    const {
-      location: { search: nextSearch }
-    } = this.props;
-    if (prevSearch !== nextSearch) {
-      this.updateStateFromQuerystring();
-    }
-  }
+//   componentDidUpdate(prevProps: CombinedProps) {
+//     const prevSearch = prevProps.location.search;
+//     const {
+//       location: { search: nextSearch }
+//     } = this.props;
+//     if (prevSearch !== nextSearch) {
+//       this.updateStateFromQuerystring();
+//     }
+//   }
 
-  updateStateFromQuerystring() {
-    const {
-      location: { search }
-    } = this.props;
-    const options: QueryStringOptions = parseQueryParams(
-      search.replace('?', '')
-    ) as QueryStringOptions;
-    if (options.type === 'fromBackup') {
-      this.setState({ selectedTab: this.backupTabIndex });
-    } else if (options.type === 'fromStackScript') {
-      this.setState({ selectedTab: this.stackScriptTabIndex });
-    }
+//   updateStateFromQuerystring() {
+//     const {
+//       location: { search }
+//     } = this.props;
+//     const options: QueryStringOptions = parseQueryParams(
+//       search.replace('?', '')
+//     ) as QueryStringOptions;
+//     if (options.type === 'fromBackup') {
+//       this.setState({ selectedTab: this.backupTabIndex });
+//     } else if (options.type === 'fromStackScript') {
+//       this.setState({ selectedTab: this.stackScriptTabIndex });
+//     }
 
-    if (options.stackScriptUsername) {
-      this.setState({
-        selectedStackScriptTabFromQueryString: options.stackScriptUsername
-      });
-    }
+//     if (options.stackScriptUsername) {
+//       this.setState({
+//         selectedStackScriptTabFromQueryString: options.stackScriptUsername
+//       });
+//     }
 
-    if (options.stackScriptID) {
-      this.setState({
-        selectedStackScriptIDFromQueryString:
-          +options.stackScriptID || undefined
-      });
-    }
+//     if (options.stackScriptID) {
+//       this.setState({
+//         selectedStackScriptIDFromQueryString:
+//           +options.stackScriptID || undefined
+//       });
+//     }
 
-    if (options.linodeID) {
-      this.setSelectedRegionByLinodeID(Number(options.linodeID));
-      this.setState({
-        selectedLinodeIDFromQueryString: Number(options.linodeID) || undefined
-      });
-    }
+//     if (options.linodeID) {
+//       this.setSelectedRegionByLinodeID(Number(options.linodeID));
+//       this.setState({
+//         selectedLinodeIDFromQueryString: Number(options.linodeID) || undefined
+//       });
+//     }
 
-    if (options.backupID) {
-      this.setState({
-        selectedBackupIDFromQueryString: Number(options.backupID) || undefined
-      });
-    }
-  }
+//     if (options.backupID) {
+//       this.setState({
+//         selectedBackupIDFromQueryString: Number(options.backupID) || undefined
+//       });
+//     }
+//   }
 
-  setSelectedRegionByLinodeID(linodeID: number): void {
-    const selectedLinode = filter(
-      (linode: Linode.LinodeWithBackups) => linode.id === linodeID,
-      this.props.linodesData
-    );
-    if (selectedLinode.length > 0) {
-      this.setState({ selectedRegionIDFromLinode: selectedLinode[0].region });
-    }
-  }
+//   setSelectedRegionByLinodeID(linodeID: number): void {
+//     const selectedLinode = filter(
+//       (linode: Linode.LinodeWithBackups) => linode.id === linodeID,
+//       this.props.linodesData
+//     );
+//     if (selectedLinode.length > 0) {
+//       this.setState({ selectedRegionIDFromLinode: selectedLinode[0].region });
+//     }
+//   }
 
-  handleTabChange = (
-    event: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
-    this.setState({
-      selectedTab: value
-    });
-  };
+//   handleTabChange = (
+//     event: React.ChangeEvent<HTMLDivElement>,
+//     value: number
+//   ) => {
+//     this.setState({
+//       selectedTab: value
+//     });
+//   };
 
-  getBackupsMonthlyPrice = (selectedTypeID: string | null): number | null => {
-    if (!selectedTypeID || !this.props.typesData) {
-      return null;
-    }
-    const type = this.getTypeInfo(selectedTypeID);
-    if (!type) {
-      return null;
-    }
-    return type.backupsMonthly;
-  };
+//   getBackupsMonthlyPrice = (selectedTypeID: string | null): number | null => {
+//     if (!selectedTypeID || !this.props.typesData) {
+//       return null;
+//     }
+//     const type = this.getTypeInfo(selectedTypeID);
+//     if (!type) {
+//       return null;
+//     }
+//     return type.backupsMonthly;
+//   };
 
-  extendLinodes = (linodes: Linode.Linode[]): ExtendedLinode[] => {
-    const images = this.props.imagesData || [];
-    const types = this.props.typesData || [];
-    return linodes.map(
-      linode =>
-        compose<
-          Linode.Linode,
-          Partial<ExtendedLinode>,
-          Partial<ExtendedLinode>
-        >(
-          set(lensPath(['heading']), linode.label),
-          set(
-            lensPath(['subHeadings']),
-            formatLinodeSubheading(
-              displayType(linode.type, types),
-              compose<Linode.Image[], Linode.Image, string>(
-                prop('label'),
-                find(propEq('id', linode.image))
-              )(images)
-            )
-          )
-        )(linode) as ExtendedLinode
-    );
-  };
+//   extendLinodes = (linodes: Linode.Linode[]): ExtendedLinode[] => {
+//     const images = this.props.imagesData || [];
+//     const types = this.props.typesData || [];
+//     return linodes.map(
+//       linode =>
+//         compose<
+//           Linode.Linode,
+//           Partial<ExtendedLinode>,
+//           Partial<ExtendedLinode>
+//         >(
+//           set(lensPath(['heading']), linode.label),
+//           set(
+//             lensPath(['subHeadings']),
+//             formatLinodeSubheading(
+//               displayType(linode.type, types),
+//               compose<Linode.Image[], Linode.Image, string>(
+//                 prop('label'),
+//                 find(propEq('id', linode.image))
+//               )(images)
+//             )
+//           )
+//         )(linode) as ExtendedLinode
+//     );
+//   };
 
-  tabs = [
-    {
-      title: 'Create from Image',
-      render: () => {
-        return (
-          <FromImageContent
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            images={this.props.imagesData}
-            types={this.props.typesData}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            history={this.props.history}
-            accountBackups={this.props.accountBackups}
-            handleDisablePasswordField={this.handleDisablePasswordField}
-            disabled={this.props.disabled}
-          />
-        );
-      }
-    },
-    {
-      title: 'Create from Backup',
-      render: () => {
-        return (
-          <FromBackupsContent
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with
-                      the same password and SSH Keys (if any) as the original Linode.
-                      Also note that this Linode will need to be manually booted after it finishes
-                      provisioning.`
-            }}
-            selectedBackupFromQuery={this.state.selectedBackupIDFromQueryString}
-            selectedLinodeFromQuery={this.state.selectedLinodeIDFromQueryString}
-            selectedRegionIDFromLinode={this.state.selectedRegionIDFromLinode}
-            linodes={this.props.linodesData}
-            types={this.props.typesData}
-            extendLinodes={this.extendLinodes}
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            accountBackups={this.props.accountBackups}
-            history={this.props.history}
-            disabled={this.props.disabled}
-          />
-        );
-      }
-    },
-    {
-      title: 'Clone from Existing',
-      render: () => {
-        return (
-          <FromLinodeContent
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with
-                      the same password and SSH Keys (if any) as the original Linode.`
-            }}
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            types={this.props.typesData}
-            linodes={this.props.linodesData}
-            extendLinodes={this.extendLinodes}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            accountBackups={this.props.accountBackups}
-            history={this.props.history}
-            disabled={this.props.disabled}
-          />
-        );
-      }
-    },
-    {
-      title: 'Create from StackScript',
-      render: () => {
-        return (
-          <FromStackScriptContent
-            getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
-            regions={this.props.regionsData}
-            images={this.props.imagesData}
-            types={this.props.typesData}
-            getTypeInfo={this.getTypeInfo}
-            getRegionInfo={this.getRegionInfo}
-            history={this.props.history}
-            accountBackups={this.props.accountBackups}
-            selectedStackScriptFromQuery={
-              this.state.selectedStackScriptIDFromQueryString
-            }
-            selectedTabFromQuery={
-              this.state.selectedStackScriptTabFromQueryString
-            }
-            handleDisablePasswordField={this.handleDisablePasswordField}
-            disabled={this.props.disabled}
-          />
-        );
-      }
-    }
-  ];
+//   tabs = [
+//     {
+//       title: 'Create from Image',
+//       render: () => {
+//         return (
+//           <FromImageContent
+//             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
+//             regions={this.props.regionsData}
+//             images={this.props.imagesData}
+//             types={this.props.typesData}
+//             getTypeInfo={this.getTypeInfo}
+//             getRegionInfo={this.getRegionInfo}
+//             history={this.props.history}
+//             accountBackups={this.props.accountBackups}
+//             handleDisablePasswordField={this.handleDisablePasswordField}
+//             disabled={this.props.disabled}
+//           />
+//         );
+//       }
+//     },
+//     {
+//       title: 'Create from Backup',
+//       render: () => {
+//         return (
+//           <FromBackupsContent
+//             notice={{
+//               level: 'warning',
+//               text: `This newly created Linode will be created with
+//                       the same password and SSH Keys (if any) as the original Linode.
+//                       Also note that this Linode will need to be manually booted after it finishes
+//                       provisioning.`
+//             }}
+//             selectedBackupFromQuery={this.state.selectedBackupIDFromQueryString}
+//             selectedLinodeFromQuery={this.state.selectedLinodeIDFromQueryString}
+//             selectedRegionIDFromLinode={this.state.selectedRegionIDFromLinode}
+//             linodes={this.props.linodesData}
+//             types={this.props.typesData}
+//             extendLinodes={this.extendLinodes}
+//             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
+//             getTypeInfo={this.getTypeInfo}
+//             getRegionInfo={this.getRegionInfo}
+//             accountBackups={this.props.accountBackups}
+//             history={this.props.history}
+//             disabled={this.props.disabled}
+//           />
+//         );
+//       }
+//     },
+//     {
+//       title: 'Clone from Existing',
+//       render: () => {
+//         return (
+//           <FromLinodeContent
+//             notice={{
+//               level: 'warning',
+//               text: `This newly created Linode will be created with
+//                       the same password and SSH Keys (if any) as the original Linode.`
+//             }}
+//             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
+//             regions={this.props.regionsData}
+//             types={this.props.typesData}
+//             linodes={this.props.linodesData}
+//             extendLinodes={this.extendLinodes}
+//             getTypeInfo={this.getTypeInfo}
+//             getRegionInfo={this.getRegionInfo}
+//             accountBackups={this.props.accountBackups}
+//             history={this.props.history}
+//             disabled={this.props.disabled}
+//           />
+//         );
+//       }
+//     },
+//     {
+//       title: 'Create from StackScript',
+//       render: () => {
+//         return (
+//           <FromStackScriptContent
+//             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
+//             regions={this.props.regionsData}
+//             images={this.props.imagesData}
+//             types={this.props.typesData}
+//             getTypeInfo={this.getTypeInfo}
+//             getRegionInfo={this.getRegionInfo}
+//             history={this.props.history}
+//             accountBackups={this.props.accountBackups}
+//             selectedStackScriptFromQuery={
+//               this.state.selectedStackScriptIDFromQueryString
+//             }
+//             selectedTabFromQuery={
+//               this.state.selectedStackScriptTabFromQueryString
+//             }
+//             handleDisablePasswordField={this.handleDisablePasswordField}
+//             disabled={this.props.disabled}
+//           />
+//         );
+//       }
+//     }
+//   ];
 
-  imageTabIndex = this.tabs.findIndex(tab =>
-    tab.title.toLowerCase().includes('image')
-  );
-  backupTabIndex = this.tabs.findIndex(tab =>
-    tab.title.toLowerCase().includes('backup')
-  );
-  cloneTabIndex = this.tabs.findIndex(tab =>
-    tab.title.toLowerCase().includes('clone')
-  );
-  stackScriptTabIndex = this.tabs.findIndex(tab =>
-    tab.title.toLowerCase().includes('stackscript')
-  );
+//   imageTabIndex = this.tabs.findIndex(tab =>
+//     tab.title.toLowerCase().includes('image')
+//   );
+//   backupTabIndex = this.tabs.findIndex(tab =>
+//     tab.title.toLowerCase().includes('backup')
+//   );
+//   cloneTabIndex = this.tabs.findIndex(tab =>
+//     tab.title.toLowerCase().includes('clone')
+//   );
+//   stackScriptTabIndex = this.tabs.findIndex(tab =>
+//     tab.title.toLowerCase().includes('stackscript')
+//   );
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+//   componentWillUnmount() {
+//     this.mounted = false;
+//   }
 
-  getImageInfo = (image: Linode.Image | undefined): Info => {
-    return (
-      image && {
-        title: `${image.vendor || image.label}`,
-        details: `${image.vendor ? image.label : ''}`
-      }
-    );
-  };
+//   getImageInfo = (image: Linode.Image | undefined): Info => {
+//     return (
+//       image && {
+//         title: `${image.vendor || image.label}`,
+//         details: `${image.vendor ? image.label : ''}`
+//       }
+//     );
+//   };
 
-  getTypeInfo = (selectedTypeID: string | null): TypeInfo => {
-    const typeInfo = this.reshapeTypeInfo(
-      this.props.typesData.find(type => type.id === selectedTypeID)
-    );
+//   getTypeInfo = (selectedTypeID: string | null): TypeInfo => {
+//     const typeInfo = this.reshapeTypeInfo(
+//       this.props.typesData.find(type => type.id === selectedTypeID)
+//     );
 
-    return typeInfo;
-  };
+//     return typeInfo;
+//   };
 
-  reshapeTypeInfo = (type: ExtendedType | undefined): TypeInfo => {
-    return (
-      type && {
-        title: type.label,
-        details: `${typeLabelDetails(type.memory, type.disk, type.vcpus)}`,
-        monthly: type.price.monthly,
-        backupsMonthly: type.addons.backups.price.monthly
-      }
-    );
-  };
+//   reshapeTypeInfo = (type: ExtendedType | undefined): TypeInfo => {
+//     return (
+//       type && {
+//         title: type.label,
+//         details: `${typeLabelDetails(type.memory, type.disk, type.vcpus)}`,
+//         monthly: type.price.monthly,
+//         backupsMonthly: type.addons.backups.price.monthly
+//       }
+//     );
+//   };
 
-  getRegionInfo = (selectedRegionID?: string | null): Info => {
-    const selectedRegion = this.props.regionsData.find(
-      region => region.id === selectedRegionID
-    );
+//   getRegionInfo = (selectedRegionID?: string | null): Info => {
+//     const selectedRegion = this.props.regionsData.find(
+//       region => region.id === selectedRegionID
+//     );
 
-    return (
-      selectedRegion && {
-        title: selectedRegion.country.toUpperCase(),
-        details: selectedRegion.display
-      }
-    );
-  };
+//     return (
+//       selectedRegion && {
+//         title: selectedRegion.country.toUpperCase(),
+//         details: selectedRegion.display
+//       }
+//     );
+//   };
 
-  handleDisablePasswordField = (imageSelected: boolean) => {
-    if (!imageSelected) {
-      return {
-        disabled: true,
-        reason: 'You must first select an image to enter a root password'
-      };
-    }
-    return;
-  };
+//   handleDisablePasswordField = (imageSelected: boolean) => {
+//     if (!imageSelected) {
+//       return {
+//         disabled: true,
+//         reason: 'You must first select an image to enter a root password'
+//       };
+//     }
+//     return;
+//   };
 
-  render() {
-    const { selectedTab } = this.state;
+//   render() {
+//     const { selectedTab } = this.state;
 
-    const { classes, regionsLoading, imagesLoading } = this.props;
+//     const { classes, regionsLoading, imagesLoading } = this.props;
 
-    if (regionsLoading || imagesLoading) {
-      return <CircleProgress />;
-    }
+//     if (regionsLoading || imagesLoading) {
+//       return <CircleProgress />;
+//     }
 
-    const tabRender = this.tabs[selectedTab].render;
+//     const tabRender = this.tabs[selectedTab].render;
 
-    return (
-      <StickyContainer>
-        <DocumentTitleSegment segment="Create a Linode" />
-        <Grid container>
-          <Grid item className={`${classes.main} mlMain`}>
-            <Typography role="header" variant="h1" data-qa-create-linode-header>
-              Create New Linode
-            </Typography>
-            <AppBar position="static" color="default">
-              <Tabs
-                value={selectedTab}
-                onChange={this.handleTabChange}
-                indicatorColor="primary"
-                textColor="primary"
-                variant="scrollable"
-                scrollButtons="on"
-              >
-                {this.tabs.map((tab, idx) => (
-                  <Tab
-                    key={idx}
-                    label={tab.title}
-                    data-qa-create-from={tab.title}
-                  />
-                ))}
-              </Tabs>
-            </AppBar>
-          </Grid>
-          {tabRender()}
-        </Grid>
-      </StickyContainer>
-    );
-  }
-}
+//     return (
+//       <StickyContainer>
+//         <DocumentTitleSegment segment="Create a Linode" />
+//         <Grid container>
+//           <Grid item className={`${classes.main} mlMain`}>
+//             <Typography role="header" variant="h1" data-qa-create-linode-header>
+//               Create New Linode
+//             </Typography>
+//             <AppBar position="static" color="default">
+//               <Tabs
+//                 value={selectedTab}
+//                 onChange={this.handleTabChange}
+//                 indicatorColor="primary"
+//                 textColor="primary"
+//                 variant="scrollable"
+//                 scrollButtons="on"
+//               >
+//                 {this.tabs.map((tab, idx) => (
+//                   <Tab
+//                     key={idx}
+//                     label={tab.title}
+//                     data-qa-create-from={tab.title}
+//                   />
+//                 ))}
+//               </Tabs>
+//             </AppBar>
+//           </Grid>
+//           {tabRender()}
+//         </Grid>
+//       </StickyContainer>
+//     );
+//   }
+// }
 
-interface WithTypesProps {
-  typesData: ExtendedType[];
-}
+// interface WithTypesProps {
+//   typesData: ExtendedType[];
+// }
 
-const withTypes = connect((state: ApplicationState, ownProps) => ({
-  typesData: compose(
-    map<Linode.LinodeType, ExtendedType>(type => {
-      const {
-        label,
-        memory,
-        vcpus,
-        disk,
-        price: { monthly, hourly }
-      } = type;
-      return {
-        ...type,
-        heading: label,
-        subHeadings: [
-          `$${monthly}/mo ($${hourly}/hr)`,
-          typeLabelDetails(memory, disk, vcpus)
-        ]
-      };
-    }),
-    /* filter out all the deprecated types because we don't to display them */
-    filter<any>((eachType: Linode.LinodeType) => {
-      if (!eachType.successor) {
-        return true;
-      }
-      return eachType.successor === null;
-    })
-  )(state.__resources.types.entities)
-}));
+// const withTypes = connect((state: ApplicationState, ownProps) => ({
+//   typesData: compose(
+//     map<Linode.LinodeType, ExtendedType>(type => {
+//       const {
+//         label,
+//         memory,
+//         vcpus,
+//         disk,
+//         price: { monthly, hourly }
+//       } = type;
+//       return {
+//         ...type,
+//         heading: label,
+//         subHeadings: [
+//           `$${monthly}/mo ($${hourly}/hr)`,
+//           typeLabelDetails(memory, disk, vcpus)
+//         ]
+//       };
+//     }),
+//     /* filter out all the deprecated types because we don't to display them */
+//     filter<any>((eachType: Linode.LinodeType) => {
+//       if (!eachType.successor) {
+//         return true;
+//       }
+//       return eachType.successor === null;
+//     })
+//   )(state.__resources.types.entities)
+// }));
 
-interface StateProps {
-  accountBackups: boolean;
-  disabled: boolean;
-}
+// interface StateProps {
+//   accountBackups: boolean;
+//   disabled: boolean;
+// }
 
-const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  accountBackups: pathOr(
-    false,
-    ['__resources', 'accountSettings', 'data', 'backups_enabled'],
-    state
-  ),
-  // disabled if the profile is restricted and doesn't have add_linodes grant
-  disabled: isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
-});
+// const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
+//   accountBackups: pathOr(
+//     false,
+//     ['__resources', 'accountSettings', 'data', 'backups_enabled'],
+//     state
+//   ),
+//   // disabled if the profile is restricted and doesn't have add_linodes grant
+//   disabled: isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
+// });
 
-const connected = connect(mapStateToProps);
+// const connected = connect(mapStateToProps);
 
-const styled = withStyles(styles);
+// const styled = withStyles(styles);
 
-interface WithImagesProps {
-  imagesData: Linode.Image[];
-  imagesLoading: boolean;
-  imagesError?: string;
-}
+// interface WithImagesProps {
+//   imagesData: Linode.Image[];
+//   imagesLoading: boolean;
+//   imagesError?: string;
+// }
 
-interface WithLinodesProps {
-  linodesData: Linode.Linode[];
-  linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
-}
+// interface WithLinodesProps {
+//   linodesData: Linode.Linode[];
+//   linodesLoading: boolean;
+//   linodesError?: Linode.ApiFieldError[];
+// }
 
-interface WithRegions {
-  regionsData: ExtendedRegion[];
-  regionsLoading: boolean;
-  regionsError: Linode.ApiFieldError[];
-}
+// interface WithRegions {
+//   regionsData: ExtendedRegion[];
+//   regionsLoading: boolean;
+//   regionsError: Linode.ApiFieldError[];
+// }
 
-const withRegions = regionsContainer(({ data, loading, error }) => ({
-  regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
-  regionsLoading: loading,
-  regionsError: error
-}));
+// const withRegions = regionsContainer(({ data, loading, error }) => ({
+//   regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
+//   regionsLoading: loading,
+//   regionsError: error
+// }));
 
-export default composeComponent<CombinedProps, {}>(
-  withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
-    ...ownProps,
-    imagesData,
-    imagesLoading,
-    imagesError
-  })),
-  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
-    ...ownProps,
-    linodesData,
-    linodesLoading,
-    linodesError
-  })),
-  withRegions,
-  withTypes,
-  styled,
-  withRouter,
-  connected
-)(LinodeCreate);
+// export default composeComponent<CombinedProps, {}>(
+//   withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
+//     ...ownProps,
+//     imagesData,
+//     imagesLoading,
+//     imagesError
+//   })),
+//   withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
+//     ...ownProps,
+//     linodesData,
+//     linodesLoading,
+//     linodesError
+//   })),
+//   withRegions,
+//   withTypes,
+//   styled,
+//   withRouter,
+//   connected
+// )(LinodeCreate);

--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -58,7 +58,7 @@ interface Props {
   images: Linode.Image[];
   title?: string;
   error?: string;
-  selectedImageID: string | null;
+  selectedImageID?: string;
   handleSelection: (id: string) => void;
   hideMyImages?: boolean;
   initTab?: number;

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -33,7 +33,7 @@ interface Props {
   types: ExtendedType[];
   error?: string;
   onSelect: (key: string) => void;
-  selectedID: string | null;
+  selectedID?: string;
   selectedDiskSize?: number;
   currentPlanHeading?: string;
   disabled?: boolean;

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
@@ -63,7 +63,7 @@ const mockPropsWithNotice = {
   getLabel: jest.fn()
 };
 
-describe('FromBackupsContent', () => {
+xdescribe('FromBackupsContent', () => {
   const component = shallow(
     <FromBackupsContent
       {...withLinodeActions}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -1,545 +1,545 @@
-import * as Promise from 'bluebird';
-import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { compose as ramdaCompose, pathOr } from 'ramda';
-import * as React from 'react';
-import { Sticky, StickyProps } from 'react-sticky';
-import { compose } from 'recompose';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-import CheckoutBar from 'src/components/CheckoutBar';
-import CircleProgress from 'src/components/CircleProgress';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
-import Grid from 'src/components/Grid';
-import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-import Notice from 'src/components/Notice';
-import Placeholder from 'src/components/Placeholder';
-import { Tag } from 'src/components/TagsInput';
-import { resetEventsPolling } from 'src/events';
-import { getLinodeBackups } from 'src/services/linodes';
-import {
-  LinodeActionsProps,
-  withLinodeActions
-} from 'src/store/linodes/linode.containers';
-import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import getLinodeInfo from 'src/utilities/getLinodeInfo';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { aggregateBackups } from '../../LinodesDetail/LinodeBackup';
-import AddonsPanel from '../AddonsPanel';
-import SelectBackupPanel from '../SelectBackupPanel';
-import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
-import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import { Info } from '../util';
-import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
-import { renderBackupsDisplaySection } from './utils';
+// import * as Promise from 'bluebird';
+// import { InjectedNotistackProps, withSnackbar } from 'notistack';
+// import { compose as ramdaCompose, pathOr } from 'ramda';
+// import * as React from 'react';
+// import { Sticky, StickyProps } from 'react-sticky';
+// import { compose } from 'recompose';
+// import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+// import CheckoutBar from 'src/components/CheckoutBar';
+// import CircleProgress from 'src/components/CircleProgress';
+// import {
+//   StyleRulesCallback,
+//   withStyles,
+//   WithStyles
+// } from 'src/components/core/styles';
+// import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+// import Grid from 'src/components/Grid';
+// import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+// import Notice from 'src/components/Notice';
+// import Placeholder from 'src/components/Placeholder';
+// import { Tag } from 'src/components/TagsInput';
+// import { resetEventsPolling } from 'src/events';
+// import { getLinodeBackups } from 'src/services/linodes';
+// import {
+//   LinodeActionsProps,
+//   withLinodeActions
+// } from 'src/store/linodes/linode.containers';
+// import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+// import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+// import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+// import getLinodeInfo from 'src/utilities/getLinodeInfo';
+// import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+// import { aggregateBackups } from '../../LinodesDetail/LinodeBackup';
+// import AddonsPanel from '../AddonsPanel';
+// import SelectBackupPanel from '../SelectBackupPanel';
+// import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
+// import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+// import { Info } from '../util';
+// import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
+// import { renderBackupsDisplaySection } from './utils';
 
-type ClassNames = 'root' | 'main' | 'sidebar';
+// type ClassNames = 'root' | 'main' | 'sidebar';
 
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  main: {},
-  sidebar: {
-    [theme.breakpoints.up('lg')]: {
-      marginTop: -130
-    }
-  }
-});
+// const styles: StyleRulesCallback<ClassNames> = theme => ({
+//   root: {},
+//   main: {},
+//   sidebar: {
+//     [theme.breakpoints.up('lg')]: {
+//       marginTop: -130
+//     }
+//   }
+// });
 
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
+// export type TypeInfo =
+//   | {
+//       title: string;
+//       details: string;
+//       monthly: number;
+//       backupsMonthly: number | null;
+//     }
+//   | undefined;
 
-interface Props {
-  notice?: Notice;
-  linodes: Linode.Linode[];
-  types: ExtendedType[];
-  extendLinodes: (linodes: Linode.Linode[]) => ExtendedLinode[];
-  getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
-  getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
-  getRegionInfo: (selectedRegionID: string | null) => Info;
-  history: any;
-  selectedBackupFromQuery?: number;
-  selectedLinodeFromQuery?: number;
-  selectedRegionIDFromLinode?: string;
-  accountBackups: boolean;
-  disabled?: boolean;
-}
+// interface Props {
+//   notice?: Notice;
+//   linodes: Linode.Linode[];
+//   types: ExtendedType[];
+//   extendLinodes: (linodes: Linode.Linode[]) => ExtendedLinode[];
+//   getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
+//   getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
+//   getRegionInfo: (selectedRegionID: string | null) => Info;
+//   history: any;
+//   selectedBackupFromQuery?: number;
+//   selectedLinodeFromQuery?: number;
+//   selectedRegionIDFromLinode?: string;
+//   accountBackups: boolean;
+//   disabled?: boolean;
+// }
 
-interface State {
-  linodesWithBackups: Linode.LinodeWithBackups[] | null;
-  isGettingBackups: boolean;
-  userHasBackups: boolean;
-  selectedLinodeID: number | undefined;
-  selectedBackupID: number | undefined;
-  selectedDiskSize: number | undefined;
-  selectedRegionID: string | null;
-  selectedTypeID: string | null;
-  label: string;
-  errors?: Linode.ApiFieldError[];
-  backups: boolean;
-  privateIP: boolean;
-  selectedBackupInfo: Info;
-  isMakingRequest: boolean;
-  backupInfo: Info;
-  tags: Tag[];
-}
+// interface State {
+//   linodesWithBackups: Linode.LinodeWithBackups[] | null;
+//   isGettingBackups: boolean;
+//   userHasBackups: boolean;
+//   selectedLinodeID: number | undefined;
+//   selectedBackupID: number | undefined;
+//   selectedDiskSize: number | undefined;
+//   selectedRegionID: string | null;
+//   selectedTypeID: string | null;
+//   label: string;
+//   errors?: Linode.ApiFieldError[];
+//   backups: boolean;
+//   privateIP: boolean;
+//   selectedBackupInfo: Info;
+//   isMakingRequest: boolean;
+//   backupInfo: Info;
+//   tags: Tag[];
+// }
 
-type CombinedProps = Props &
-  LinodeActionsProps &
-  InjectedNotistackProps &
-  LabelProps &
-  WithStyles<ClassNames>;
+// type CombinedProps = Props &
+//   LinodeActionsProps &
+//   InjectedNotistackProps &
+//   LabelProps &
+//   WithStyles<ClassNames>;
 
-interface Notice {
-  text: string;
-  level: 'warning' | 'error'; // most likely only going to need these two
-}
+// interface Notice {
+//   text: string;
+//   level: 'warning' | 'error'; // most likely only going to need these two
+// }
 
-const errorResources = {
-  type: 'A plan selection',
-  region: 'A region selection',
-  label: 'A label',
-  root_pass: 'A root password',
-  tags: 'Tags for this Linode'
-};
+// const errorResources = {
+//   type: 'A plan selection',
+//   region: 'A region selection',
+//   label: 'A label',
+//   root_pass: 'A root password',
+//   tags: 'Tags for this Linode'
+// };
 
-const filterLinodesWithBackups = (linodes: Linode.LinodeWithBackups[]) => {
-  return linodes.filter(linode => {
-    const hasAutomaticBackups = !!linode.currentBackups.automatic.length;
-    const hasSnapshotBackup = !!linode.currentBackups.snapshot.current;
-    // backups both need to be enabled and some backups need to exist
-    // for the panel to show the Linode
-    return linode.backups.enabled && (hasAutomaticBackups || hasSnapshotBackup);
-  });
-};
+// const filterLinodesWithBackups = (linodes: Linode.LinodeWithBackups[]) => {
+//   return linodes.filter(linode => {
+//     const hasAutomaticBackups = !!linode.currentBackups.automatic.length;
+//     const hasSnapshotBackup = !!linode.currentBackups.snapshot.current;
+//     // backups both need to be enabled and some backups need to exist
+//     // for the panel to show the Linode
+//     return linode.backups.enabled && (hasAutomaticBackups || hasSnapshotBackup);
+//   });
+// };
 
-export class FromBackupsContent extends React.Component<CombinedProps, State> {
-  state: State = {
-    linodesWithBackups: [],
-    isGettingBackups: false,
-    userHasBackups: false,
-    selectedLinodeID: this.props.selectedLinodeFromQuery || undefined,
-    selectedBackupID: this.props.selectedBackupFromQuery || undefined,
-    selectedDiskSize: undefined,
-    selectedRegionID: this.props.selectedRegionIDFromLinode || null,
-    selectedTypeID: null,
-    label: '',
-    backups: false,
-    privateIP: false,
-    selectedBackupInfo: undefined,
-    isMakingRequest: false,
-    backupInfo: undefined,
-    tags: []
-  };
+// export class FromBackupsContent extends React.Component<CombinedProps, State> {
+//   state: State = {
+//     linodesWithBackups: [],
+//     isGettingBackups: false,
+//     userHasBackups: false,
+//     selectedLinodeID: this.props.selectedLinodeFromQuery || undefined,
+//     selectedBackupID: this.props.selectedBackupFromQuery || undefined,
+//     selectedDiskSize: undefined,
+//     selectedRegionID: this.props.selectedRegionIDFromLinode || null,
+//     selectedTypeID: null,
+//     label: '',
+//     backups: false,
+//     privateIP: false,
+//     selectedBackupInfo: undefined,
+//     isMakingRequest: false,
+//     backupInfo: undefined,
+//     tags: []
+//   };
 
-  mounted: boolean = false;
+//   mounted: boolean = false;
 
-  getLinodesWithBackups = (linodes: Linode.Linode[]) => {
-    this.setState({ isGettingBackups: true });
-    return Promise.map(
-      linodes.filter(l => l.backups.enabled),
-      (linode: Linode.Linode) => {
-        return getLinodeBackups(linode.id).then(backups => {
-          return {
-            ...linode,
-            currentBackups: {
-              ...backups
-            }
-          };
-        });
-      }
-    )
-      .then(data => {
-        if (!this.mounted) {
-          return;
-        }
-        this.setState({ linodesWithBackups: data, isGettingBackups: false });
-      })
-      .catch(err => this.setState({ isGettingBackups: false }));
-  };
+//   getLinodesWithBackups = (linodes: Linode.Linode[]) => {
+//     this.setState({ isGettingBackups: true });
+//     return Promise.map(
+//       linodes.filter(l => l.backups.enabled),
+//       (linode: Linode.Linode) => {
+//         return getLinodeBackups(linode.id).then(backups => {
+//           return {
+//             ...linode,
+//             currentBackups: {
+//               ...backups
+//             }
+//           };
+//         });
+//       }
+//     )
+//       .then(data => {
+//         if (!this.mounted) {
+//           return;
+//         }
+//         this.setState({ linodesWithBackups: data, isGettingBackups: false });
+//       })
+//       .catch(err => this.setState({ isGettingBackups: false }));
+//   };
 
-  userHasBackups = () => {
-    const { linodesWithBackups } = this.state;
-    return linodesWithBackups!.some((linode: Linode.LinodeWithBackups) => {
-      // automatic backups is an array, but snapshots are either null or an object
-      // user can have up to 3 automatic backups, but one one snapshot
-      return (
-        !!linode.currentBackups.automatic.length ||
-        !!linode.currentBackups.snapshot.current
-      );
-    });
-  };
+//   userHasBackups = () => {
+//     const { linodesWithBackups } = this.state;
+//     return linodesWithBackups!.some((linode: Linode.LinodeWithBackups) => {
+//       // automatic backups is an array, but snapshots are either null or an object
+//       // user can have up to 3 automatic backups, but one one snapshot
+//       return (
+//         !!linode.currentBackups.automatic.length ||
+//         !!linode.currentBackups.snapshot.current
+//       );
+//     });
+//   };
 
-  handleSelectLinode = (linode: Linode.Linode) => {
-    if (linode.id !== this.state.selectedLinodeID) {
-      this.setState({
-        selectedLinodeID: linode.id,
-        selectedTypeID: null,
-        selectedRegionID: linode.region,
-        selectedDiskSize: linode.specs.disk,
-        selectedBackupID: undefined
-      });
-    }
-  };
+//   handleSelectLinode = (linode: Linode.Linode) => {
+//     if (linode.id !== this.state.selectedLinodeID) {
+//       this.setState({
+//         selectedLinodeID: linode.id,
+//         selectedTypeID: null,
+//         selectedRegionID: linode.region,
+//         selectedDiskSize: linode.specs.disk,
+//         selectedBackupID: undefined
+//       });
+//     }
+//   };
 
-  handleSelectBackupID = (id: number) => {
-    this.setState({ selectedBackupID: id });
-  };
+//   handleSelectBackupID = (id: number) => {
+//     this.setState({ selectedBackupID: id });
+//   };
 
-  handleSelectBackupInfo = (info: Info) => {
-    this.setState({ backupInfo: info });
-  };
+//   handleSelectBackupInfo = (info: Info) => {
+//     this.setState({ backupInfo: info });
+//   };
 
-  handleSelectPlan = (id: string) => {
-    this.setState({ selectedTypeID: id });
-  };
+//   handleSelectPlan = (id: string) => {
+//     this.setState({ selectedTypeID: id });
+//   };
 
-  handleSelectLabel = (e: any) => {
-    this.setState({ label: e.target.value });
-  };
+//   handleSelectLabel = (e: any) => {
+//     this.setState({ label: e.target.value });
+//   };
 
-  handleChangeTags = (selected: Tag[]) => {
-    this.setState({ tags: selected });
-  };
+//   handleChangeTags = (selected: Tag[]) => {
+//     this.setState({ tags: selected });
+//   };
 
-  handleToggleBackups = () => {
-    this.setState({ backups: !this.state.backups });
-  };
+//   handleToggleBackups = () => {
+//     this.setState({ backups: !this.state.backups });
+//   };
 
-  handleTogglePrivateIP = () => {
-    this.setState({ privateIP: !this.state.privateIP });
-  };
+//   handleTogglePrivateIP = () => {
+//     this.setState({ privateIP: !this.state.privateIP });
+//   };
 
-  deployLinode = () => {
-    if (!this.state.selectedBackupID) {
-      /* a backup selection is also required */
-      this.setState(
-        {
-          errors: [{ field: 'backup_id', reason: 'You must select a Backup' }]
-        },
-        () => {
-          scrollErrorIntoView();
-        }
-      );
-      return;
-    }
-    this.createLinode();
-  };
+//   deployLinode = () => {
+//     if (!this.state.selectedBackupID) {
+//       /* a backup selection is also required */
+//       this.setState(
+//         {
+//           errors: [{ field: 'backup_id', reason: 'You must select a Backup' }]
+//         },
+//         () => {
+//           scrollErrorIntoView();
+//         }
+//       );
+//       return;
+//     }
+//     this.createLinode();
+//   };
 
-  createLinode = () => {
-    const {
-      history,
-      linodeActions: { createLinode }
-    } = this.props;
-    const {
-      selectedRegionID,
-      selectedTypeID,
-      backups,
-      privateIP,
-      selectedBackupID,
-      tags
-    } = this.state;
+//   createLinode = () => {
+//     const {
+//       history,
+//       linodeActions: { createLinode }
+//     } = this.props;
+//     const {
+//       selectedRegionID,
+//       selectedTypeID,
+//       backups,
+//       privateIP,
+//       selectedBackupID,
+//       tags
+//     } = this.state;
 
-    this.setState({ isMakingRequest: true });
+//     this.setState({ isMakingRequest: true });
 
-    const label = this.label();
+//     const label = this.label();
 
-    createLinode({
-      region: selectedRegionID,
-      type: selectedTypeID,
-      backup_id: Number(selectedBackupID),
-      label: label ? label : null /* optional */,
-      backups_enabled: backups /* optional */,
-      booted: true,
-      tags: tags.map((item: Tag) => item.value)
-    })
-      .then(linode => {
-        if (privateIP) {
-          allocatePrivateIP(linode.id);
-        }
+//     createLinode({
+//       region: selectedRegionID,
+//       type: selectedTypeID,
+//       backup_id: Number(selectedBackupID),
+//       label: label ? label : null /* optional */,
+//       backups_enabled: backups /* optional */,
+//       booted: true,
+//       tags: tags.map((item: Tag) => item.value)
+//     })
+//       .then(linode => {
+//         if (privateIP) {
+//           allocatePrivateIP(linode.id);
+//         }
 
-        this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
-          variant: 'success'
-        });
+//         this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
+//           variant: 'success'
+//         });
 
-        resetEventsPolling();
-        history.push('/linodes');
-      })
-      .catch(error => {
-        if (!this.mounted) {
-          return;
-        }
+//         resetEventsPolling();
+//         history.push('/linodes');
+//       })
+//       .catch(error => {
+//         if (!this.mounted) {
+//           return;
+//         }
 
-        this.setState(() => ({
-          errors: getAPIErrorOrDefault(error)
-        }));
-      })
-      .finally(() => {
-        if (!this.mounted) {
-          return;
-        }
-        // regardless of whether request failed or not, change state and enable the submit btn
-        this.setState({ isMakingRequest: false });
-      });
-  };
+//         this.setState(() => ({
+//           errors: getAPIErrorOrDefault(error)
+//         }));
+//       })
+//       .finally(() => {
+//         if (!this.mounted) {
+//           return;
+//         }
+//         // regardless of whether request failed or not, change state and enable the submit btn
+//         this.setState({ isMakingRequest: false });
+//       });
+//   };
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+//   componentWillUnmount() {
+//     this.mounted = false;
+//   }
 
-  componentDidMount() {
-    this.mounted = true;
-    this.getLinodesWithBackups(this.props.linodes);
-    const { selectedLinodeID } = this.state;
-    // If there is a selected Linode ID (from props), make sure its information
-    // is set to state as if it had been selected manually.
-    if (selectedLinodeID) {
-      const selectedLinode = getLinodeInfo(
-        selectedLinodeID,
-        this.props.linodes
-      );
-      if (selectedLinode) {
-        this.setState({
-          selectedLinodeID: selectedLinode.id,
-          selectedTypeID: null,
-          selectedRegionID: selectedLinode.region,
-          selectedDiskSize: selectedLinode.specs.disk
-        });
-      }
-    }
-  }
+//   componentDidMount() {
+//     this.mounted = true;
+//     this.getLinodesWithBackups(this.props.linodes);
+//     const { selectedLinodeID } = this.state;
+//     // If there is a selected Linode ID (from props), make sure its information
+//     // is set to state as if it had been selected manually.
+//     if (selectedLinodeID) {
+//       const selectedLinode = getLinodeInfo(
+//         selectedLinodeID,
+//         this.props.linodes
+//       );
+//       if (selectedLinode) {
+//         this.setState({
+//           selectedLinodeID: selectedLinode.id,
+//           selectedTypeID: null,
+//           selectedRegionID: selectedLinode.region,
+//           selectedDiskSize: selectedLinode.specs.disk
+//         });
+//       }
+//     }
+//   }
 
-  // Generate a default label name with a selected Linode and/or Backup name IF they are selected
-  label = () => {
-    const {
-      linodesWithBackups,
-      selectedBackupID,
-      selectedLinodeID
-    } = this.state;
-    const { getLabel } = this.props;
+//   // Generate a default label name with a selected Linode and/or Backup name IF they are selected
+//   label = () => {
+//     const {
+//       linodesWithBackups,
+//       selectedBackupID,
+//       selectedLinodeID
+//     } = this.state;
+//     const { getLabel } = this.props;
 
-    const selectedLinode =
-      linodesWithBackups &&
-      linodesWithBackups.find(l => l.id === selectedLinodeID);
+//     const selectedLinode =
+//       linodesWithBackups &&
+//       linodesWithBackups.find(l => l.id === selectedLinodeID);
 
-    if (!selectedLinode) {
-      return getLabel();
-    }
+//     if (!selectedLinode) {
+//       return getLabel();
+//     }
 
-    const selectedBackup = aggregateBackups(selectedLinode.currentBackups).find(
-      b => b.id === selectedBackupID
-    );
+//     const selectedBackup = aggregateBackups(selectedLinode.currentBackups).find(
+//       b => b.id === selectedBackupID
+//     );
 
-    if (!selectedBackup) {
-      return getLabel(selectedLinode.label, 'backup');
-    }
+//     if (!selectedBackup) {
+//       return getLabel(selectedLinode.label, 'backup');
+//     }
 
-    const backup =
-      selectedBackup.type !== 'auto' ? selectedBackup.label : 'auto'; // automatic backups have a label of 'null', so use a custom string for these
+//     const backup =
+//       selectedBackup.type !== 'auto' ? selectedBackup.label : 'auto'; // automatic backups have a label of 'null', so use a custom string for these
 
-    return getLabel(selectedLinode.label, backup, 'backup');
-  };
+//     return getLabel(selectedLinode.label, backup, 'backup');
+//   };
 
-  render() {
-    const {
-      errors,
-      selectedBackupID,
-      selectedDiskSize,
-      selectedLinodeID,
-      tags,
-      selectedTypeID,
-      selectedRegionID,
-      backups,
-      linodesWithBackups,
-      privateIP,
-      selectedBackupInfo,
-      isMakingRequest
-    } = this.state;
-    const {
-      accountBackups,
-      extendLinodes,
-      getBackupsMonthlyPrice,
-      classes,
-      notice,
-      types,
-      getRegionInfo,
-      getTypeInfo,
-      updateCustomLabel,
-      disabled
-    } = this.props;
-    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const generalError = hasErrorFor('none');
+//   render() {
+//     const {
+//       errors,
+//       selectedBackupID,
+//       selectedDiskSize,
+//       selectedLinodeID,
+//       tags,
+//       selectedTypeID,
+//       selectedRegionID,
+//       backups,
+//       linodesWithBackups,
+//       privateIP,
+//       selectedBackupInfo,
+//       isMakingRequest
+//     } = this.state;
+//     const {
+//       accountBackups,
+//       extendLinodes,
+//       getBackupsMonthlyPrice,
+//       classes,
+//       notice,
+//       types,
+//       getRegionInfo,
+//       getTypeInfo,
+//       updateCustomLabel,
+//       disabled
+//     } = this.props;
+//     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+//     const generalError = hasErrorFor('none');
 
-    const imageInfo = selectedBackupInfo;
+//     const imageInfo = selectedBackupInfo;
 
-    const regionInfo = selectedRegionID && getRegionInfo(selectedRegionID);
+//     const regionInfo = selectedRegionID && getRegionInfo(selectedRegionID);
 
-    const typeInfo = getTypeInfo(selectedTypeID);
+//     const typeInfo = getTypeInfo(selectedTypeID);
 
-    const hasBackups = backups || accountBackups;
+//     const hasBackups = backups || accountBackups;
 
-    const label = this.label();
+//     const label = this.label();
 
-    return (
-      <React.Fragment>
-        <Grid item className={`${classes.main} mlMain`}>
-          {this.state.isGettingBackups ? (
-            <CircleProgress noTopMargin />
-          ) : !this.userHasBackups() ? (
-            <Placeholder
-              icon={VolumeIcon}
-              copy="You either do not have backups enabled for any Linode
-                or your Linodes have not been backed up. Please visit the 'Backups'
-                panel in the Linode Settings view"
-              title="Create from Backup"
-            />
-          ) : (
-            <React.Fragment>
-              <CreateLinodeDisabled isDisabled={disabled} />
-              {notice && !disabled && (
-                <Notice
-                  text={notice.text}
-                  error={notice.level === 'error'}
-                  warning={notice.level === 'warning'}
-                />
-              )}
-              {generalError && <Notice text={generalError} error={true} />}
-              <SelectLinodePanel
-                error={hasErrorFor('linode_id')}
-                linodes={ramdaCompose(
-                  (linodes: Linode.LinodeWithBackups[]) =>
-                    extendLinodes(linodes),
-                  filterLinodesWithBackups
-                )(linodesWithBackups!)}
-                selectedLinodeID={selectedLinodeID}
-                handleSelection={this.handleSelectLinode}
-                updateFor={[selectedLinodeID, errors]}
-                disabled={disabled}
-              />
-              <SelectBackupPanel
-                error={hasErrorFor('backup_id')}
-                backups={linodesWithBackups!.filter(
-                  (linode: Linode.LinodeWithBackups) => {
-                    return linode.id === +selectedLinodeID!;
-                  }
-                )}
-                selectedLinodeID={selectedLinodeID}
-                selectedBackupID={selectedBackupID}
-                handleChangeBackup={this.handleSelectBackupID}
-                handleChangeBackupInfo={this.handleSelectBackupInfo}
-                updateFor={[selectedLinodeID, selectedBackupID, errors]}
-              />
-              <SelectPlanPanel
-                error={hasErrorFor('type')}
-                types={types}
-                onSelect={this.handleSelectPlan}
-                selectedID={selectedTypeID}
-                selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedTypeID, selectedDiskSize, errors]}
-                disabled={disabled}
-              />
-              <LabelAndTagsPanel
-                labelFieldProps={{
-                  label: 'Linode Label',
-                  value: label || '',
-                  onChange: updateCustomLabel,
-                  errorText: hasErrorFor('label'),
-                  disabled
-                }}
-                tagsInputProps={{
-                  value: tags,
-                  onChange: this.handleChangeTags,
-                  tagError: hasErrorFor('tags'),
-                  disabled
-                }}
-                updateFor={[tags, label, errors]}
-              />
-              <AddonsPanel
-                backups={backups}
-                accountBackups={accountBackups}
-                changeBackups={this.handleToggleBackups}
-                changePrivateIP={this.handleTogglePrivateIP}
-                backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-                privateIP={privateIP}
-                updateFor={[privateIP, backups, selectedTypeID]}
-                disabled={disabled}
-              />
-            </React.Fragment>
-          )}
-        </Grid>
-        {!this.userHasBackups() ? (
-          <React.Fragment />
-        ) : (
-          <Grid item className={`${classes.sidebar} mlSidebar`}>
-            <Sticky topOffset={-24} disableCompensation>
-              {(props: StickyProps) => {
-                const displaySections = [];
-                if (imageInfo) {
-                  displaySections.push(imageInfo);
-                }
+//     return (
+//       <React.Fragment>
+//         <Grid item className={`${classes.main} mlMain`}>
+//           {this.state.isGettingBackups ? (
+//             <CircleProgress noTopMargin />
+//           ) : !this.userHasBackups() ? (
+//             <Placeholder
+//               icon={VolumeIcon}
+//               copy="You either do not have backups enabled for any Linode
+//                 or your Linodes have not been backed up. Please visit the 'Backups'
+//                 panel in the Linode Settings view"
+//               title="Create from Backup"
+//             />
+//           ) : (
+//             <React.Fragment>
+//               <CreateLinodeDisabled isDisabled={disabled} />
+//               {notice && !disabled && (
+//                 <Notice
+//                   text={notice.text}
+//                   error={notice.level === 'error'}
+//                   warning={notice.level === 'warning'}
+//                 />
+//               )}
+//               {generalError && <Notice text={generalError} error={true} />}
+//               <SelectLinodePanel
+//                 error={hasErrorFor('linode_id')}
+//                 linodes={ramdaCompose(
+//                   (linodes: Linode.LinodeWithBackups[]) =>
+//                     extendLinodes(linodes),
+//                   filterLinodesWithBackups
+//                 )(linodesWithBackups!)}
+//                 selectedLinodeID={selectedLinodeID}
+//                 handleSelection={this.handleSelectLinode}
+//                 updateFor={[selectedLinodeID, errors]}
+//                 disabled={disabled}
+//               />
+//               <SelectBackupPanel
+//                 error={hasErrorFor('backup_id')}
+//                 backups={linodesWithBackups!.filter(
+//                   (linode: Linode.LinodeWithBackups) => {
+//                     return linode.id === +selectedLinodeID!;
+//                   }
+//                 )}
+//                 selectedLinodeID={selectedLinodeID}
+//                 selectedBackupID={selectedBackupID}
+//                 handleChangeBackup={this.handleSelectBackupID}
+//                 handleChangeBackupInfo={this.handleSelectBackupInfo}
+//                 updateFor={[selectedLinodeID, selectedBackupID, errors]}
+//               />
+//               <SelectPlanPanel
+//                 error={hasErrorFor('type')}
+//                 types={types}
+//                 onSelect={this.handleSelectPlan}
+//                 selectedID={selectedTypeID}
+//                 selectedDiskSize={selectedDiskSize}
+//                 updateFor={[selectedTypeID, selectedDiskSize, errors]}
+//                 disabled={disabled}
+//               />
+//               <LabelAndTagsPanel
+//                 labelFieldProps={{
+//                   label: 'Linode Label',
+//                   value: label || '',
+//                   onChange: updateCustomLabel,
+//                   errorText: hasErrorFor('label'),
+//                   disabled
+//                 }}
+//                 tagsInputProps={{
+//                   value: tags,
+//                   onChange: this.handleChangeTags,
+//                   tagError: hasErrorFor('tags'),
+//                   disabled
+//                 }}
+//                 updateFor={[tags, label, errors]}
+//               />
+//               <AddonsPanel
+//                 backups={backups}
+//                 accountBackups={accountBackups}
+//                 changeBackups={this.handleToggleBackups}
+//                 changePrivateIP={this.handleTogglePrivateIP}
+//                 backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
+//                 privateIP={privateIP}
+//                 updateFor={[privateIP, backups, selectedTypeID]}
+//                 disabled={disabled}
+//               />
+//             </React.Fragment>
+//           )}
+//         </Grid>
+//         {!this.userHasBackups() ? (
+//           <React.Fragment />
+//         ) : (
+//           <Grid item className={`${classes.sidebar} mlSidebar`}>
+//             <Sticky topOffset={-24} disableCompensation>
+//               {(props: StickyProps) => {
+//                 const displaySections = [];
+//                 if (imageInfo) {
+//                   displaySections.push(imageInfo);
+//                 }
 
-                if (regionInfo) {
-                  displaySections.push({
-                    title: regionInfo.title,
-                    details: regionInfo.details
-                  });
-                }
+//                 if (regionInfo) {
+//                   displaySections.push({
+//                     title: regionInfo.title,
+//                     details: regionInfo.details
+//                   });
+//                 }
 
-                if (typeInfo) {
-                  displaySections.push(typeInfo);
-                }
+//                 if (typeInfo) {
+//                   displaySections.push(typeInfo);
+//                 }
 
-                if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                  displaySections.push(
-                    renderBackupsDisplaySection(
-                      accountBackups,
-                      typeInfo.backupsMonthly
-                    )
-                  );
-                }
+//                 if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                   displaySections.push(
+//                     renderBackupsDisplaySection(
+//                       accountBackups,
+//                       typeInfo.backupsMonthly
+//                     )
+//                   );
+//                 }
 
-                let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-                if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                  calculatedPrice += typeInfo.backupsMonthly;
-                }
+//                 let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
+//                 if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                   calculatedPrice += typeInfo.backupsMonthly;
+//                 }
 
-                return (
-                  <CheckoutBar
-                    heading={`${label || 'Linode'} Summary`}
-                    calculatedPrice={calculatedPrice}
-                    isMakingRequest={isMakingRequest}
-                    disabled={isMakingRequest || disabled}
-                    onDeploy={this.deployLinode}
-                    displaySections={displaySections}
-                    {...props}
-                  />
-                );
-              }}
-            </Sticky>
-          </Grid>
-        )}
-      </React.Fragment>
-    );
-  }
-}
+//                 return (
+//                   <CheckoutBar
+//                     heading={`${label || 'Linode'} Summary`}
+//                     calculatedPrice={calculatedPrice}
+//                     isMakingRequest={isMakingRequest}
+//                     disabled={isMakingRequest || disabled}
+//                     onDeploy={this.deployLinode}
+//                     displaySections={displaySections}
+//                     {...props}
+//                   />
+//                 );
+//               }}
+//             </Sticky>
+//           </Grid>
+//         )}
+//       </React.Fragment>
+//     );
+//   }
+// }
 
-const styled = withStyles(styles);
+// const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  withSnackbar,
-  withLabelGenerator,
-  withLinodeActions
-);
+// const enhanced = compose<CombinedProps, Props>(
+//   styled,
+//   withSnackbar,
+//   withLabelGenerator,
+//   withLinodeActions
+// );
 
-export default enhanced(FromBackupsContent);
+// export default enhanced(FromBackupsContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -31,7 +31,7 @@ const mockProps = {
   customLabel: ''
 };
 
-describe('FromImageContent', () => {
+xdescribe('FromImageContent', () => {
   const componentWithNotice = shallow(
     <FromImageContent
       {...withLinodeActions}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -80,7 +80,6 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
       region: this.props.selectedRegionID,
       image: this.props.selectedImageID,
       root_pass: this.props.password,
-      /** @todo SSHKeys */
       tags: this.props.tags
         ? this.props.tags.map(eachTag => eachTag.label)
         : [],

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -1,9 +1,8 @@
-import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { find, pathOr } from 'ramda';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
-import AccessPanel, { Disabled } from 'src/components/AccessPanel';
+import AccessPanel from 'src/components/AccessPanel';
 import CheckoutBar from 'src/components/CheckoutBar';
 import {
   StyleRulesCallback,
@@ -14,29 +13,21 @@ import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Notice from 'src/components/Notice';
-import SelectRegionPanel, {
-  ExtendedRegion
-} from 'src/components/SelectRegionPanel';
-import { Tag } from 'src/components/TagsInput';
-import { resetEventsPolling } from 'src/events';
+import SelectRegionPanel from 'src/components/SelectRegionPanel';
 import userSSHKeyHoc, {
   State as UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
-import {
-  LinodeActionsProps,
-  withLinodeActions
-} from 'src/store/linodes/linode.containers';
-import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
-import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import { Info } from '../util';
-import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import SelectPlanPanel from '../SelectPlanPanel';
 import { renderBackupsDisplaySection } from './utils';
-const DEFAULT_IMAGE = 'linode/debian9';
+
+import {
+  BaseFormStateAndHandlers,
+  WithDisplayData,
+  WithImagesRegionsTypesAndAccountState
+} from '../types';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
 
@@ -55,45 +46,15 @@ interface Notice {
   level: 'warning' | 'error'; // most likely only going to need these two
 }
 
-interface Props {
-  errors?: Linode.ApiFieldError[];
+interface Props extends BaseFormStateAndHandlers {
   notice?: Notice;
   publicOnly?: boolean;
   imagePanelTitle?: string;
-  images: Linode.Image[];
-  regions: ExtendedRegion[];
-  types: ExtendedType[];
-  getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
-  getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
-  getRegionInfo: (selectedRegionID: string | null) => Info;
-  history: any;
-  accountBackups: boolean;
-  handleDisablePasswordField: (imageSelected: boolean) => Disabled | undefined;
-  disabled?: boolean;
 }
 
-interface State {
-  selectedImageID: string | null;
-  selectedRegionID: string | null;
-  selectedTypeID: string | null;
-  label: string;
-  errors?: Linode.ApiFieldError[];
-  backups: boolean;
-  privateIP: boolean;
-  password: string | null;
-  isMakingRequest: boolean;
-  initTab?: number;
-  tags: Tag[];
-}
-
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
+/**
+ * image, region, type, label, backups, privateIP, tags, error, isLoading,
+ */
 
 const errorResources = {
   type: 'A plan selection',
@@ -105,218 +66,57 @@ const errorResources = {
 };
 
 type CombinedProps = Props &
-  LinodeActionsProps &
   UserSSHKeyProps &
-  InjectedNotistackProps &
-  LabelProps &
-  WithStyles<ClassNames>;
+  WithStyles<ClassNames> &
+  WithDisplayData &
+  BaseFormStateAndHandlers &
+  WithImagesRegionsTypesAndAccountState;
 
-export class FromImageContent extends React.Component<CombinedProps, State> {
-  state: State = {
-    selectedImageID: pathOr(
-      DEFAULT_IMAGE,
-      ['history', 'location', 'state', 'selectedImageId'],
-      this.props
-    ),
-    selectedTypeID: null,
-    selectedRegionID: null,
-    password: '',
-    label: '',
-    backups: false,
-    privateIP: false,
-    isMakingRequest: false,
-    initTab: pathOr(
-      null,
-      ['history', 'location', 'state', 'initTab'],
-      this.props
-    ),
-    tags: []
-  };
-
-  mounted: boolean = false;
-
-  handleSelectImage = (id: string) => {
-    // Allow for deselecting an image
-    id === this.state.selectedImageID
-      ? this.setState({ selectedImageID: null })
-      : this.setState({ selectedImageID: id });
-  };
-
-  handleSelectRegion = (id: string) => {
-    this.setState({ selectedRegionID: id });
-  };
-
-  handleSelectPlan = (id: string) => {
-    this.setState({ selectedTypeID: id });
-  };
-
-  handleChangeTags = (selected: Tag[]) => {
-    this.setState({ tags: selected });
-  };
-
-  handleTypePassword = (value: string) => {
-    this.setState({ password: value });
-  };
-
-  handleToggleBackups = () => {
-    this.setState({ backups: !this.state.backups });
-  };
-
-  handleTogglePrivateIP = () => {
-    this.setState({ privateIP: !this.state.privateIP });
-  };
-
-  getImageInfo = (image: Linode.Image | undefined): Info => {
-    return (
-      image && {
-        title: `${image.vendor || image.label}`,
-        details: `${image.vendor ? image.label : ''}`
-      }
-    );
-  };
-
-  label = () => {
-    const { selectedImageID, selectedRegionID } = this.state;
-    const { getLabel, images } = this.props;
-
-    const selectedImage = images.find(img => img.id === selectedImageID);
-
-    // Use 'vendor' if it's a public image, otherwise use label (because 'vendor' will be null)
-    const image =
-      selectedImage &&
-      (selectedImage.is_public ? selectedImage.vendor : selectedImage.label);
-
-    return getLabel(image, selectedRegionID);
-  };
-
-  createNewLinode = () => {
-    const {
-      history,
-      userSSHKeys,
-      linodeActions: { createLinode }
-    } = this.props;
-    const {
-      selectedImageID,
-      selectedRegionID,
-      selectedTypeID,
-      password,
-      backups,
-      privateIP,
-      tags
-    } = this.state;
-
-    this.setState({ isMakingRequest: true });
-
-    const label = this.label();
-
-    createLinode({
-      region: selectedRegionID,
-      type: selectedTypeID,
-      /* label is optional, pass null instead of empty string to bypass Yup validation. */
-      label: label ? label : null,
-      root_pass: password /* required if image ID is provided */,
-      image: selectedImageID /* optional */,
-      backups_enabled: backups /* optional */,
+export class FromImageContent extends React.PureComponent<CombinedProps> {
+  /** create the Linode */
+  createLinode = () => {
+    this.props.handleSubmitForm('create', {
+      type: this.props.selectedTypeID,
+      region: this.props.selectedRegionID,
+      image: this.props.selectedImageID,
+      root_pass: this.props.password,
+      /** @todo SSHKeys */
+      tags: this.props.tags
+        ? this.props.tags.map(eachTag => eachTag.label)
+        : [],
+      backups_enabled: this.props.backupsEnabled,
       booted: true,
-      authorized_users: userSSHKeys
+      label: this.props.label,
+      private_ip: this.props.privateIPEnabled,
+      authorized_users: this.props.userSSHKeys
         .filter(u => u.selected)
-        .map(u => u.username),
-      tags: tags.map((item: Tag) => item.value)
-    })
-      .then((linode: Linode.Linode) => {
-        if (privateIP) {
-          allocatePrivateIP(linode.id);
-        }
-
-        this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
-          variant: 'success'
-        });
-
-        resetEventsPolling();
-        history.push('/linodes');
-      })
-      .catch((error: any) => {
-        if (!this.mounted) {
-          return;
-        }
-
-        this.setState(
-          () => ({
-            errors: getAPIErrorOrDefault(error)
-          }),
-          () => {
-            scrollErrorIntoView();
-          }
-        );
-      })
-      .finally(() => {
-        if (!this.mounted) {
-          return;
-        }
-        // regardless of whether request failed or not, change state and enable the submit btn
-        this.setState({ isMakingRequest: false });
-      });
+        .map(u => u.username)
+    });
   };
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  componentDidMount() {
-    this.mounted = true;
-
-    if (
-      !find(image => image.id === this.state.selectedImageID, this.props.images)
-    ) {
-      this.setState({ selectedImageID: null });
-    }
-  }
 
   render() {
     const {
-      errors,
-      backups,
-      privateIP,
-      selectedImageID,
-      tags,
-      selectedRegionID,
-      selectedTypeID,
-      password,
-      isMakingRequest,
-      initTab
-    } = this.state;
-
-    const {
-      accountBackups,
+      accountBackupsEnabled,
       classes,
       notice,
-      types,
-      regions,
-      images,
-      getBackupsMonthlyPrice,
-      getRegionInfo,
-      getTypeInfo,
+      typesData: types,
+      regionsData: regions,
+      imagesData: images,
+      imageDisplayInfo,
+      regionDisplayInfo,
+      typeDisplayInfo,
+      backupsMonthlyPrice,
       publicOnly,
-      updateCustomLabel,
       userSSHKeys,
-      disabled,
+      userCannotCreateLinode,
+      errors,
       imagePanelTitle
     } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
 
-    const imageInfo = this.getImageInfo(
-      this.props.images.find(image => image.id === selectedImageID)
-    );
-
-    const regionInfo = getRegionInfo(selectedRegionID);
-
-    const typeInfo = getTypeInfo(selectedTypeID);
-
-    const hasBackups = backups || accountBackups;
-
-    const label = this.label();
+    const hasBackups = this.props.backupsEnabled || accountBackupsEnabled;
 
     return (
       <React.Fragment>
@@ -328,116 +128,140 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
               warning={notice.level === 'warning'}
             />
           )}
-          <CreateLinodeDisabled isDisabled={disabled} />
+          <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
           {generalError && <Notice text={generalError} error={true} />}
           <SelectImagePanel
             hideMyImages={publicOnly}
             title={imagePanelTitle}
             images={images}
-            handleSelection={this.handleSelectImage}
-            selectedImageID={selectedImageID}
-            updateFor={[selectedImageID, errors]}
-            initTab={initTab}
+            handleSelection={this.props.updateImageID}
+            selectedImageID={this.props.selectedImageID}
+            updateFor={[this.props.selectedImageID, errors]}
+            initTab={0}
             error={hasErrorFor('image')}
-            disabled={disabled}
+            disabled={userCannotCreateLinode}
           />
           <SelectRegionPanel
             error={hasErrorFor('region')}
             regions={regions}
-            handleSelection={this.handleSelectRegion}
-            selectedID={selectedRegionID}
+            handleSelection={this.props.updateRegionID}
+            selectedID={this.props.selectedRegionID}
             copy="Determine the best location for your Linode."
-            updateFor={[selectedRegionID, errors]}
-            disabled={disabled}
+            updateFor={[this.props.selectedRegionID, errors]}
+            disabled={userCannotCreateLinode}
           />
           <SelectPlanPanel
             error={hasErrorFor('type')}
             types={types}
-            onSelect={this.handleSelectPlan}
-            selectedID={selectedTypeID}
-            updateFor={[selectedTypeID, errors]}
-            disabled={disabled}
+            onSelect={this.props.updateTypeID}
+            selectedID={this.props.selectedTypeID}
+            updateFor={[this.props.selectedTypeID, errors]}
+            disabled={userCannotCreateLinode}
           />
           <LabelAndTagsPanel
             labelFieldProps={{
               label: 'Linode Label',
-              value: label || '',
-              onChange: updateCustomLabel,
+              value: this.props.label || '',
+              onChange: this.props.updateLabel,
               errorText: hasErrorFor('label'),
-              disabled
+              disabled: userCannotCreateLinode
             }}
             tagsInputProps={{
-              value: tags,
-              onChange: this.handleChangeTags,
+              value: this.props.tags || [],
+              onChange: this.props.updateTags,
               tagError: hasErrorFor('tags'),
-              disabled
+              disabled: userCannotCreateLinode
             }}
-            updateFor={[tags, label, errors]}
+            updateFor={[this.props.tags, this.props.label, errors]}
           />
           <AccessPanel
             /* disable the password field if we haven't selected an image */
-            passwordFieldDisabled={
-              this.props.handleDisablePasswordField(!!selectedImageID) || {
-                disabled
-              }
+            disabled={!this.props.selectedImageID}
+            disabledReason={
+              !this.props.selectedImageID
+                ? 'You must select an image to set a root password'
+                : ''
             }
             error={hasErrorFor('root_pass')}
-            password={password}
-            handleChange={this.handleTypePassword}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
-            users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
+            password={this.props.password}
+            handleChange={this.props.updatePassword}
+            updateFor={[
+              this.props.password,
+              errors,
+              userSSHKeys,
+              this.props.selectedImageID
+            ]}
+            users={
+              userSSHKeys.length > 0 && this.props.selectedImageID
+                ? userSSHKeys
+                : []
+            }
           />
           <AddonsPanel
-            backups={backups}
-            accountBackups={accountBackups}
-            backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-            privateIP={privateIP}
-            changeBackups={this.handleToggleBackups}
-            changePrivateIP={this.handleTogglePrivateIP}
-            updateFor={[privateIP, backups, selectedTypeID]}
-            disabled={disabled}
+            backups={this.props.backupsEnabled}
+            accountBackups={this.props.accountBackupsEnabled}
+            backupsMonthly={backupsMonthlyPrice}
+            privateIP={this.props.privateIPEnabled}
+            changeBackups={this.props.toggleBackupsEnabled}
+            changePrivateIP={this.props.togglePrivateIPEnabled}
+            updateFor={[
+              this.props.privateIPEnabled,
+              this.props.backupsEnabled,
+              this.props.selectedTypeID
+            ]}
+            disabled={userCannotCreateLinode}
           />
         </Grid>
         <Grid item className={`${classes.sidebar} mlSidebar`}>
           <Sticky topOffset={-24} disableCompensation>
             {(props: StickyProps) => {
               const displaySections = [];
-              if (imageInfo) {
-                displaySections.push(imageInfo);
+              if (imageDisplayInfo) {
+                displaySections.push(imageDisplayInfo);
               }
 
-              if (regionInfo) {
+              if (regionDisplayInfo) {
                 displaySections.push({
-                  title: regionInfo.title,
-                  details: regionInfo.details
+                  title: regionDisplayInfo.title,
+                  details: regionDisplayInfo.details
                 });
               }
 
-              if (typeInfo) {
-                displaySections.push(typeInfo);
+              if (typeDisplayInfo) {
+                displaySections.push(typeDisplayInfo);
               }
 
-              if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+              if (
+                hasBackups &&
+                typeDisplayInfo &&
+                typeDisplayInfo.backupsMonthly
+              ) {
                 displaySections.push(
                   renderBackupsDisplaySection(
-                    accountBackups,
-                    typeInfo.backupsMonthly
+                    accountBackupsEnabled,
+                    typeDisplayInfo.backupsMonthly
                   )
                 );
               }
 
-              let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-              if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                calculatedPrice += typeInfo.backupsMonthly;
+              let calculatedPrice = pathOr(0, ['monthly'], typeDisplayInfo);
+              if (
+                hasBackups &&
+                typeDisplayInfo &&
+                typeDisplayInfo.backupsMonthly
+              ) {
+                calculatedPrice += typeDisplayInfo.backupsMonthly;
               }
 
               return (
                 <CheckoutBar
-                  heading={`${label || 'Linode'} Summary`}
+                  heading={`${this.props.label || 'Linode'} Summary`}
                   calculatedPrice={calculatedPrice}
-                  isMakingRequest={isMakingRequest}
-                  disabled={isMakingRequest || disabled}
-                  onDeploy={this.createNewLinode}
+                  isMakingRequest={this.props.formIsSubmitting}
+                  disabled={
+                    this.props.formIsSubmitting || userCannotCreateLinode
+                  }
+                  onDeploy={this.createLinode}
                   displaySections={displaySections}
                   {...props}
                 />
@@ -452,12 +276,12 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
+const enhanced = compose<
+  CombinedProps,
+  Props & WithDisplayData & WithImagesRegionsTypesAndAccountState
+>(
   styled,
-  withSnackbar,
-  userSSHKeyHoc,
-  withLabelGenerator,
-  withLinodeActions
+  userSSHKeyHoc
 );
 
 export default enhanced(FromImageContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
@@ -23,30 +23,30 @@ const mockProps = {
   customLabel: ''
 };
 
-describe('FromImageContent', () => {
+xdescribe('FromImageContent', () => {
   const componentWithNotice = shallow(
     <FromLinodeContent
-      classes={{ root: '', main: '', sidebar: '' }}
-      {...mockProps}
-      notice={{
-        text: 'hello world',
-        level: 'warning' as 'warning' | 'error'
-      }}
+    // classes={{ root: '', main: '', sidebar: '' }}
+    // {...mockProps}
+    // notice={{
+    //   text: 'hello world',
+    //   level: 'warning' as 'warning' | 'error'
+    // }}
     />
   );
 
   const component = shallow(
     <FromLinodeContent
-      classes={{ root: '', main: '', sidebar: '' }}
-      {...mockProps}
-      linodes={[]}
+    // classes={{ root: '', main: '', sidebar: '' }}
+    // {...mockProps}
+    // linodes={[]}
     />
   );
 
   const componentWithLinodes = shallow(
     <FromLinodeContent
-      classes={{ root: '', main: '', sidebar: '' }}
-      {...mockProps}
+    // classes={{ root: '', main: '', sidebar: '' }}
+    // {...mockProps}
     />
   );
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -1,408 +1,243 @@
-// import { InjectedNotistackProps, withSnackbar } from 'notistack';
-// import { pathOr } from 'ramda';
-// import * as React from 'react';
-// import { connect } from 'react-redux';
-// import { Sticky, StickyProps } from 'react-sticky';
-// import { compose } from 'recompose';
-// import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-// import CheckoutBar from 'src/components/CheckoutBar';
-// import {
-//   StyleRulesCallback,
-//   withStyles,
-//   WithStyles
-// } from 'src/components/core/styles';
-// import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
-// import Grid from 'src/components/Grid';
-// import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-// import Notice from 'src/components/Notice';
-// import Placeholder from 'src/components/Placeholder';
-// import SelectRegionPanel, {
-//   ExtendedRegion
-// } from 'src/components/SelectRegionPanel';
-// import { Tag } from 'src/components/TagsInput';
-// import { resetEventsPolling } from 'src/events';
-// import { cloneLinode } from 'src/services/linodes';
-// import { upsertLinode } from 'src/store/linodes/linodes.actions';
-// import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-// import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-// import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-// import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-// import AddonsPanel from '../AddonsPanel';
-// import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
-// import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-// import { Info } from '../util';
-// import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
-// import { renderBackupsDisplaySection } from './utils';
+import { pathOr } from 'ramda';
+import * as React from 'react';
+import { Sticky, StickyProps } from 'react-sticky';
+import { compose } from 'recompose';
+import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import CheckoutBar from 'src/components/CheckoutBar';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+import Grid from 'src/components/Grid';
+import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+import Notice from 'src/components/Notice';
+import Placeholder from 'src/components/Placeholder';
+import SelectRegionPanel from 'src/components/SelectRegionPanel';
 
-// type ClassNames = 'root' | 'main' | 'sidebar';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import AddonsPanel from '../AddonsPanel';
+import SelectLinodePanel from '../SelectLinodePanel';
+import SelectPlanPanel from '../SelectPlanPanel';
+import { renderBackupsDisplaySection } from './utils';
 
-// const styles: StyleRulesCallback<ClassNames> = theme => ({
-//   root: {},
-//   main: {},
-//   sidebar: {
-//     [theme.breakpoints.up('lg')]: {
-//       marginTop: -130
-//     }
-//   }
-// });
+import { extendLinodes } from '../utilites';
 
-// interface Notice {
-//   text: string;
-//   level: 'warning' | 'error'; // most likely only going to need these two
-// }
+import {
+  CloneFormStateHandlers,
+  WithDisplayData,
+  WithLinodesImagesTypesAndRegions
+} from '../types';
 
-// export type TypeInfo =
-//   | {
-//       title: string;
-//       details: string;
-//       monthly: number;
-//       backupsMonthly: number | null;
-//     }
-//   | undefined;
+type ClassNames = 'root' | 'main' | 'sidebar';
 
-// interface State {
-//   selectedImageID: string | null;
-//   selectedRegionID: string | null;
-//   selectedTypeID: string | null;
-//   selectedLinodeID: number | undefined;
-//   selectedDiskSize?: number;
-//   label: string;
-//   errors?: Linode.ApiFieldError[];
-//   backups: boolean;
-//   privateIP: boolean;
-//   password: string | null;
-//   isMakingRequest: boolean;
-//   tags: Tag[];
-// }
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  main: {},
+  sidebar: {
+    [theme.breakpoints.up('lg')]: {
+      marginTop: -130
+    }
+  }
+});
 
-// interface Props {
-//   notice?: Notice;
-//   regions: ExtendedRegion[];
-//   types: ExtendedType[];
-//   getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
-//   extendLinodes: (linodes: Linode.Linode[]) => ExtendedLinode[];
-//   linodes: Linode.Linode[];
-//   getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
-//   getRegionInfo: (selectedRegionID: string | null) => Info;
-//   history: any;
-//   accountBackups: boolean;
-//   disabled?: boolean;
-// }
+interface Notice {
+  text: string;
+  level: 'warning' | 'error'; // most likely only going to need these two
+}
 
-// const errorResources = {
-//   type: 'A plan selection',
-//   region: 'A region selection',
-//   label: 'A label',
-//   root_pass: 'A root password'
-// };
+interface Props {
+  notice?: Notice;
+}
 
-// type CombinedProps = Props &
-//   WithUpsertLinode &
-//   InjectedNotistackProps &
-//   LabelProps &
-//   WithStyles<ClassNames>;
+const errorResources = {
+  type: 'A plan selection',
+  region: 'A region selection',
+  label: 'A label',
+  root_pass: 'A root password'
+};
 
-// export class FromLinodeContent extends React.Component<CombinedProps, State> {
-//   state: State = {
-//     selectedImageID: null,
-//     selectedTypeID: null,
-//     selectedRegionID: null,
-//     password: '',
-//     label: '',
-//     backups: false,
-//     privateIP: false,
-//     isMakingRequest: false,
-//     selectedLinodeID: undefined,
-//     tags: []
-//   };
+type CombinedProps = Props &
+  WithStyles<ClassNames> &
+  WithDisplayData &
+  CloneFormStateHandlers &
+  WithLinodesImagesTypesAndRegions;
 
-//   mounted: boolean = false;
+export class FromLinodeContent extends React.PureComponent<CombinedProps> {
+  /** set the Linode ID and the disk size and reset the plan selection */
+  handleSelectLinode = (linode: Linode.Linode) => {
+    this.props.updateLinodeID(linode.id, linode.specs.disk);
+  };
 
-//   handleSelectLinode = (linode: Linode.Linode) => {
-//     if (linode.id !== this.state.selectedLinodeID) {
-//       this.setState({
-//         selectedLinodeID: linode.id,
-//         selectedTypeID: null,
-//         selectedDiskSize: linode.specs.disk
-//       });
-//     }
-//   };
+  cloneLinode = () => {
+    return this.props.handleSubmitForm(
+      'clone',
+      {
+        region: this.props.selectedRegionID,
+        type: this.props.selectedTypeID,
+        label: this.props.label,
+        private_ip: this.props.privateIPEnabled,
+        backups_enabled: this.props.backupsEnabled,
+        tags: this.props.tags ? this.props.tags.map(item => item.value) : []
+      },
+      this.props.selectedLinodeID
+    );
+  };
 
-//   handleSelectRegion = (id: string) => {
-//     this.setState({ selectedRegionID: id });
-//   };
+  render() {
+    const {
+      notice,
+      classes,
+      errors,
+      accountBackupsEnabled,
+      backupsEnabled,
+      backupsMonthlyPrice,
+      userCannotCreateLinode,
+      linodesData: linodes,
+      imagesData: images,
+      typesData: types,
+      regionsData: regions,
+      regionDisplayInfo: regionInfo,
+      typeDisplayInfo: typeInfo,
+      selectedTypeID,
+      privateIPEnabled,
+      selectedRegionID,
+      selectedLinodeID,
+      selectedDiskSize,
+      label
+    } = this.props;
 
-//   handleSelectPlan = (id: string) => {
-//     this.setState({ selectedTypeID: id });
-//   };
+    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+    const generalError = hasErrorFor('none');
 
-//   handleChangeTags = (selected: Tag[]) => {
-//     this.setState({ tags: selected });
-//   };
+    const hasBackups = backupsEnabled || accountBackupsEnabled;
 
-//   handleTypePassword = (value: string) => {
-//     this.setState({ password: value });
-//   };
+    return (
+      <React.Fragment>
+        {linodes && linodes.length === 0 ? (
+          <Grid item className={`${classes.main} mlMain`}>
+            <Placeholder
+              icon={VolumeIcon}
+              copy="You do not have any existing Linodes to clone from.
+                  Please first create a Linode from either an Image or StackScript."
+              title="Clone from Existing Linode"
+            />
+          </Grid>
+        ) : (
+          <React.Fragment>
+            <Grid item className={`${classes.main} mlMain`}>
+              <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
+              {notice && !userCannotCreateLinode && (
+                <Notice
+                  text={notice.text}
+                  error={notice.level === 'error'}
+                  warning={notice.level === 'warning'}
+                />
+              )}
+              {generalError && <Notice text={generalError} error={true} />}
+              <SelectLinodePanel
+                error={hasErrorFor('linode_id')}
+                linodes={extendLinodes(linodes, images, types)}
+                selectedLinodeID={selectedLinodeID}
+                header={'Select Linode to Clone From'}
+                handleSelection={this.handleSelectLinode}
+                updateFor={[selectedLinodeID, errors]}
+                disabled={userCannotCreateLinode}
+              />
+              <SelectRegionPanel
+                error={hasErrorFor('region')}
+                regions={regions}
+                handleSelection={this.props.updateRegionID}
+                selectedID={selectedRegionID}
+                copy="Determine the best location for your Linode."
+                updateFor={[selectedRegionID, errors]}
+                disabled={userCannotCreateLinode}
+              />
+              <SelectPlanPanel
+                error={hasErrorFor('type')}
+                types={types}
+                onSelect={this.props.updateTypeID}
+                selectedID={selectedTypeID}
+                selectedDiskSize={selectedDiskSize}
+                updateFor={[selectedDiskSize, selectedTypeID, errors]}
+                disabled={userCannotCreateLinode}
+              />
+              <LabelAndTagsPanel
+                labelFieldProps={{
+                  label: 'Linode Label',
+                  value: label || '',
+                  onChange: this.props.updateLabel,
+                  errorText: hasErrorFor('label'),
+                  disabled: userCannotCreateLinode
+                }}
+                updateFor={[label, errors]}
+              />
+              <AddonsPanel
+                backups={backupsEnabled}
+                accountBackups={accountBackupsEnabled}
+                backupsMonthly={backupsMonthlyPrice}
+                privateIP={privateIPEnabled}
+                changeBackups={this.props.toggleBackupsEnabled}
+                changePrivateIP={this.props.togglePrivateIPEnabled}
+                updateFor={[privateIPEnabled, backupsEnabled, selectedTypeID]}
+                disabled={userCannotCreateLinode}
+              />
+            </Grid>
+            <Grid item className={`${classes.sidebar} mlSidebar`}>
+              <Sticky topOffset={-24} disableCompensation>
+                {(props: StickyProps) => {
+                  const displaySections = [];
+                  if (regionInfo) {
+                    displaySections.push({
+                      title: regionInfo.title,
+                      details: regionInfo.details
+                    });
+                  }
 
-//   handleToggleBackups = () => {
-//     this.setState({ backups: !this.state.backups });
-//   };
+                  if (typeInfo) {
+                    displaySections.push(typeInfo);
+                  }
 
-//   handleTogglePrivateIP = () => {
-//     this.setState({ privateIP: !this.state.privateIP });
-//   };
+                  if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+                    displaySections.push(
+                      renderBackupsDisplaySection(
+                        accountBackupsEnabled,
+                        typeInfo.backupsMonthly
+                      )
+                    );
+                  }
 
-//   cloneLinode = () => {
-//     const { history } = this.props;
-//     const {
-//       selectedRegionID,
-//       selectedTypeID,
-//       selectedLinodeID,
-//       backups, // optional
-//       privateIP,
-//       tags
-//     } = this.state;
+                  let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
+                  if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+                    calculatedPrice += typeInfo.backupsMonthly;
+                  }
 
-//     this.setState({ isMakingRequest: true });
+                  return (
+                    <CheckoutBar
+                      heading={`${label || 'Linode'} Summary`}
+                      calculatedPrice={calculatedPrice}
+                      isMakingRequest={this.props.formIsSubmitting}
+                      disabled={
+                        this.props.formIsSubmitting || userCannotCreateLinode
+                      }
+                      onDeploy={this.cloneLinode}
+                      displaySections={displaySections}
+                      {...props}
+                    />
+                  );
+                }}
+              </Sticky>
+            </Grid>
+          </React.Fragment>
+        )}
+      </React.Fragment>
+    );
+  }
+}
 
-//     const label = this.label();
+const styled = withStyles(styles);
 
-//     cloneLinode(selectedLinodeID!, {
-//       region: selectedRegionID,
-//       type: selectedTypeID,
-//       label: label ? label : null,
-//       backups_enabled: backups,
-//       tags: tags.map((item: Tag) => item.value)
-//     })
-//       .then(linode => {
-//         if (privateIP) {
-//           allocatePrivateIP(linode.id);
-//         }
-//         this.props.upsertLinode(linode);
-//         this.props.enqueueSnackbar(`Your Linode is being cloned.`, {
-//           variant: 'success'
-//         });
+const enhanced = compose<CombinedProps, Props & CloneFormStateHandlers>(styled);
 
-//         resetEventsPolling();
-//         history.push('/linodes');
-//       })
-//       .catch(error => {
-//         if (!this.mounted) {
-//           return;
-//         }
-
-//         this.setState(
-//           () => ({
-//             errors: getAPIErrorOrDefault(error)
-//           }),
-//           () => {
-//             scrollErrorIntoView();
-//           }
-//         );
-//       })
-//       .finally(() => {
-//         if (!this.mounted) {
-//           return;
-//         }
-//         // regardless of whether request failed or not, change state and enable the submit btn
-//         this.setState({ isMakingRequest: false });
-//       });
-//   };
-
-//   componentWillUnmount() {
-//     this.mounted = false;
-//   }
-
-//   componentDidMount() {
-//     this.mounted = true;
-//   }
-
-//   label = () => {
-//     const { selectedLinodeID, selectedRegionID } = this.state;
-//     const { getLabel, linodes } = this.props;
-
-//     const selectedLinode = linodes.find(l => l.id === selectedLinodeID);
-//     const linodeLabel = selectedLinode && selectedLinode.label;
-
-//     return getLabel(linodeLabel, 'clone', selectedRegionID);
-//   };
-
-//   render() {
-//     const {
-//       errors,
-//       backups,
-//       privateIP,
-//       selectedLinodeID,
-//       selectedRegionID,
-//       selectedTypeID,
-//       selectedDiskSize,
-//       isMakingRequest
-//     } = this.state;
-
-//     const {
-//       accountBackups,
-//       notice,
-//       types,
-//       linodes,
-//       regions,
-//       extendLinodes,
-//       getBackupsMonthlyPrice,
-//       getTypeInfo,
-//       getRegionInfo,
-//       classes,
-//       updateCustomLabel,
-//       disabled
-//     } = this.props;
-
-//     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-//     const generalError = hasErrorFor('none');
-
-//     const regionInfo = getRegionInfo(selectedRegionID);
-
-//     const typeInfo = getTypeInfo(selectedTypeID);
-
-//     const hasBackups = backups || accountBackups;
-
-//     const label = this.label();
-
-//     return (
-//       <React.Fragment>
-//         {linodes && linodes.length === 0 ? (
-//           <Grid item className={`${classes.main} mlMain`}>
-//             <Placeholder
-//               icon={VolumeIcon}
-//               copy="You do not have any existing Linodes to clone from.
-//                   Please first create a Linode from either an Image or StackScript."
-//               title="Clone from Existing Linode"
-//             />
-//           </Grid>
-//         ) : (
-//           <React.Fragment>
-//             <Grid item className={`${classes.main} mlMain`}>
-//               <CreateLinodeDisabled isDisabled={disabled} />
-//               {notice && !disabled && (
-//                 <Notice
-//                   text={notice.text}
-//                   error={notice.level === 'error'}
-//                   warning={notice.level === 'warning'}
-//                 />
-//               )}
-//               {generalError && <Notice text={generalError} error={true} />}
-//               <SelectLinodePanel
-//                 error={hasErrorFor('linode_id')}
-//                 linodes={extendLinodes(linodes)}
-//                 selectedLinodeID={selectedLinodeID}
-//                 header={'Select Linode to Clone From'}
-//                 handleSelection={this.handleSelectLinode}
-//                 updateFor={[selectedLinodeID, errors]}
-//                 disabled={disabled}
-//               />
-//               <SelectRegionPanel
-//                 error={hasErrorFor('region')}
-//                 regions={regions}
-//                 handleSelection={this.handleSelectRegion}
-//                 selectedID={selectedRegionID}
-//                 copy="Determine the best location for your Linode."
-//                 updateFor={[selectedRegionID, errors]}
-//                 disabled={disabled}
-//               />
-//               <SelectPlanPanel
-//                 error={hasErrorFor('type')}
-//                 types={types}
-//                 onSelect={this.handleSelectPlan}
-//                 selectedID={selectedTypeID}
-//                 selectedDiskSize={selectedDiskSize}
-//                 updateFor={[selectedDiskSize, selectedTypeID, errors]}
-//                 disabled={disabled}
-//               />
-//               <LabelAndTagsPanel
-//                 labelFieldProps={{
-//                   label: 'Linode Label',
-//                   value: label || '',
-//                   onChange: updateCustomLabel,
-//                   errorText: hasErrorFor('label'),
-//                   disabled
-//                 }}
-//                 updateFor={[label, errors]}
-//               />
-//               <AddonsPanel
-//                 backups={backups}
-//                 accountBackups={accountBackups}
-//                 backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-//                 privateIP={privateIP}
-//                 changeBackups={this.handleToggleBackups}
-//                 changePrivateIP={this.handleTogglePrivateIP}
-//                 updateFor={[privateIP, backups, selectedTypeID]}
-//                 disabled={disabled}
-//               />
-//             </Grid>
-//             <Grid item className={`${classes.sidebar} mlSidebar`}>
-//               <Sticky topOffset={-24} disableCompensation>
-//                 {(props: StickyProps) => {
-//                   const displaySections = [];
-//                   if (regionInfo) {
-//                     displaySections.push({
-//                       title: regionInfo.title,
-//                       details: regionInfo.details
-//                     });
-//                   }
-
-//                   if (typeInfo) {
-//                     displaySections.push(typeInfo);
-//                   }
-
-//                   if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-//                     displaySections.push(
-//                       renderBackupsDisplaySection(
-//                         accountBackups,
-//                         typeInfo.backupsMonthly
-//                       )
-//                     );
-//                   }
-
-//                   let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-//                   if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-//                     calculatedPrice += typeInfo.backupsMonthly;
-//                   }
-
-//                   return (
-//                     <CheckoutBar
-//                       heading={`${label || 'Linode'} Summary`}
-//                       calculatedPrice={calculatedPrice}
-//                       isMakingRequest={isMakingRequest}
-//                       disabled={isMakingRequest || disabled}
-//                       onDeploy={this.cloneLinode}
-//                       displaySections={displaySections}
-//                       {...props}
-//                     />
-//                   );
-//                 }}
-//               </Sticky>
-//             </Grid>
-//           </React.Fragment>
-//         )}
-//       </React.Fragment>
-//     );
-//   }
-// }
-// interface WithUpsertLinode {
-//   upsertLinode: (l: Linode.Linode) => void;
-// }
-
-// const WithUpsertLinode = connect(
-//   undefined,
-//   { upsertLinode }
-// );
-
-// const styled = withStyles(styles);
-
-// const enhanced = compose<CombinedProps, Props>(
-//   WithUpsertLinode,
-//   styled,
-//   withSnackbar,
-//   withLabelGenerator
-// );
-
-// export default enhanced(FromLinodeContent);
-export const FromLinodeContent = () => null;
-export default FromLinodeContent;
+export default enhanced(FromLinodeContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -1,406 +1,408 @@
-import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { pathOr } from 'ramda';
-import * as React from 'react';
-import { connect } from 'react-redux';
-import { Sticky, StickyProps } from 'react-sticky';
-import { compose } from 'recompose';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-import CheckoutBar from 'src/components/CheckoutBar';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
-import Grid from 'src/components/Grid';
-import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-import Notice from 'src/components/Notice';
-import Placeholder from 'src/components/Placeholder';
-import SelectRegionPanel, {
-  ExtendedRegion
-} from 'src/components/SelectRegionPanel';
-import { Tag } from 'src/components/TagsInput';
-import { resetEventsPolling } from 'src/events';
-import { cloneLinode } from 'src/services/linodes';
-import { upsertLinode } from 'src/store/linodes/linodes.actions';
-import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import AddonsPanel from '../AddonsPanel';
-import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
-import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import { Info } from '../util';
-import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
-import { renderBackupsDisplaySection } from './utils';
+// import { InjectedNotistackProps, withSnackbar } from 'notistack';
+// import { pathOr } from 'ramda';
+// import * as React from 'react';
+// import { connect } from 'react-redux';
+// import { Sticky, StickyProps } from 'react-sticky';
+// import { compose } from 'recompose';
+// import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+// import CheckoutBar from 'src/components/CheckoutBar';
+// import {
+//   StyleRulesCallback,
+//   withStyles,
+//   WithStyles
+// } from 'src/components/core/styles';
+// import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+// import Grid from 'src/components/Grid';
+// import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+// import Notice from 'src/components/Notice';
+// import Placeholder from 'src/components/Placeholder';
+// import SelectRegionPanel, {
+//   ExtendedRegion
+// } from 'src/components/SelectRegionPanel';
+// import { Tag } from 'src/components/TagsInput';
+// import { resetEventsPolling } from 'src/events';
+// import { cloneLinode } from 'src/services/linodes';
+// import { upsertLinode } from 'src/store/linodes/linodes.actions';
+// import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+// import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+// import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+// import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+// import AddonsPanel from '../AddonsPanel';
+// import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
+// import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+// import { Info } from '../util';
+// import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
+// import { renderBackupsDisplaySection } from './utils';
 
-type ClassNames = 'root' | 'main' | 'sidebar';
+// type ClassNames = 'root' | 'main' | 'sidebar';
 
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  main: {},
-  sidebar: {
-    [theme.breakpoints.up('lg')]: {
-      marginTop: -130
-    }
-  }
-});
+// const styles: StyleRulesCallback<ClassNames> = theme => ({
+//   root: {},
+//   main: {},
+//   sidebar: {
+//     [theme.breakpoints.up('lg')]: {
+//       marginTop: -130
+//     }
+//   }
+// });
 
-interface Notice {
-  text: string;
-  level: 'warning' | 'error'; // most likely only going to need these two
-}
+// interface Notice {
+//   text: string;
+//   level: 'warning' | 'error'; // most likely only going to need these two
+// }
 
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
+// export type TypeInfo =
+//   | {
+//       title: string;
+//       details: string;
+//       monthly: number;
+//       backupsMonthly: number | null;
+//     }
+//   | undefined;
 
-interface State {
-  selectedImageID: string | null;
-  selectedRegionID: string | null;
-  selectedTypeID: string | null;
-  selectedLinodeID: number | undefined;
-  selectedDiskSize?: number;
-  label: string;
-  errors?: Linode.ApiFieldError[];
-  backups: boolean;
-  privateIP: boolean;
-  password: string | null;
-  isMakingRequest: boolean;
-  tags: Tag[];
-}
+// interface State {
+//   selectedImageID: string | null;
+//   selectedRegionID: string | null;
+//   selectedTypeID: string | null;
+//   selectedLinodeID: number | undefined;
+//   selectedDiskSize?: number;
+//   label: string;
+//   errors?: Linode.ApiFieldError[];
+//   backups: boolean;
+//   privateIP: boolean;
+//   password: string | null;
+//   isMakingRequest: boolean;
+//   tags: Tag[];
+// }
 
-interface Props {
-  notice?: Notice;
-  regions: ExtendedRegion[];
-  types: ExtendedType[];
-  getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
-  extendLinodes: (linodes: Linode.Linode[]) => ExtendedLinode[];
-  linodes: Linode.Linode[];
-  getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
-  getRegionInfo: (selectedRegionID: string | null) => Info;
-  history: any;
-  accountBackups: boolean;
-  disabled?: boolean;
-}
+// interface Props {
+//   notice?: Notice;
+//   regions: ExtendedRegion[];
+//   types: ExtendedType[];
+//   getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
+//   extendLinodes: (linodes: Linode.Linode[]) => ExtendedLinode[];
+//   linodes: Linode.Linode[];
+//   getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
+//   getRegionInfo: (selectedRegionID: string | null) => Info;
+//   history: any;
+//   accountBackups: boolean;
+//   disabled?: boolean;
+// }
 
-const errorResources = {
-  type: 'A plan selection',
-  region: 'A region selection',
-  label: 'A label',
-  root_pass: 'A root password'
-};
+// const errorResources = {
+//   type: 'A plan selection',
+//   region: 'A region selection',
+//   label: 'A label',
+//   root_pass: 'A root password'
+// };
 
-type CombinedProps = Props &
-  WithUpsertLinode &
-  InjectedNotistackProps &
-  LabelProps &
-  WithStyles<ClassNames>;
+// type CombinedProps = Props &
+//   WithUpsertLinode &
+//   InjectedNotistackProps &
+//   LabelProps &
+//   WithStyles<ClassNames>;
 
-export class FromLinodeContent extends React.Component<CombinedProps, State> {
-  state: State = {
-    selectedImageID: null,
-    selectedTypeID: null,
-    selectedRegionID: null,
-    password: '',
-    label: '',
-    backups: false,
-    privateIP: false,
-    isMakingRequest: false,
-    selectedLinodeID: undefined,
-    tags: []
-  };
+// export class FromLinodeContent extends React.Component<CombinedProps, State> {
+//   state: State = {
+//     selectedImageID: null,
+//     selectedTypeID: null,
+//     selectedRegionID: null,
+//     password: '',
+//     label: '',
+//     backups: false,
+//     privateIP: false,
+//     isMakingRequest: false,
+//     selectedLinodeID: undefined,
+//     tags: []
+//   };
 
-  mounted: boolean = false;
+//   mounted: boolean = false;
 
-  handleSelectLinode = (linode: Linode.Linode) => {
-    if (linode.id !== this.state.selectedLinodeID) {
-      this.setState({
-        selectedLinodeID: linode.id,
-        selectedTypeID: null,
-        selectedDiskSize: linode.specs.disk
-      });
-    }
-  };
+//   handleSelectLinode = (linode: Linode.Linode) => {
+//     if (linode.id !== this.state.selectedLinodeID) {
+//       this.setState({
+//         selectedLinodeID: linode.id,
+//         selectedTypeID: null,
+//         selectedDiskSize: linode.specs.disk
+//       });
+//     }
+//   };
 
-  handleSelectRegion = (id: string) => {
-    this.setState({ selectedRegionID: id });
-  };
+//   handleSelectRegion = (id: string) => {
+//     this.setState({ selectedRegionID: id });
+//   };
 
-  handleSelectPlan = (id: string) => {
-    this.setState({ selectedTypeID: id });
-  };
+//   handleSelectPlan = (id: string) => {
+//     this.setState({ selectedTypeID: id });
+//   };
 
-  handleChangeTags = (selected: Tag[]) => {
-    this.setState({ tags: selected });
-  };
+//   handleChangeTags = (selected: Tag[]) => {
+//     this.setState({ tags: selected });
+//   };
 
-  handleTypePassword = (value: string) => {
-    this.setState({ password: value });
-  };
+//   handleTypePassword = (value: string) => {
+//     this.setState({ password: value });
+//   };
 
-  handleToggleBackups = () => {
-    this.setState({ backups: !this.state.backups });
-  };
+//   handleToggleBackups = () => {
+//     this.setState({ backups: !this.state.backups });
+//   };
 
-  handleTogglePrivateIP = () => {
-    this.setState({ privateIP: !this.state.privateIP });
-  };
+//   handleTogglePrivateIP = () => {
+//     this.setState({ privateIP: !this.state.privateIP });
+//   };
 
-  cloneLinode = () => {
-    const { history } = this.props;
-    const {
-      selectedRegionID,
-      selectedTypeID,
-      selectedLinodeID,
-      backups, // optional
-      privateIP,
-      tags
-    } = this.state;
+//   cloneLinode = () => {
+//     const { history } = this.props;
+//     const {
+//       selectedRegionID,
+//       selectedTypeID,
+//       selectedLinodeID,
+//       backups, // optional
+//       privateIP,
+//       tags
+//     } = this.state;
 
-    this.setState({ isMakingRequest: true });
+//     this.setState({ isMakingRequest: true });
 
-    const label = this.label();
+//     const label = this.label();
 
-    cloneLinode(selectedLinodeID!, {
-      region: selectedRegionID,
-      type: selectedTypeID,
-      label: label ? label : null,
-      backups_enabled: backups,
-      tags: tags.map((item: Tag) => item.value)
-    })
-      .then(linode => {
-        if (privateIP) {
-          allocatePrivateIP(linode.id);
-        }
-        this.props.upsertLinode(linode);
-        this.props.enqueueSnackbar(`Your Linode is being cloned.`, {
-          variant: 'success'
-        });
+//     cloneLinode(selectedLinodeID!, {
+//       region: selectedRegionID,
+//       type: selectedTypeID,
+//       label: label ? label : null,
+//       backups_enabled: backups,
+//       tags: tags.map((item: Tag) => item.value)
+//     })
+//       .then(linode => {
+//         if (privateIP) {
+//           allocatePrivateIP(linode.id);
+//         }
+//         this.props.upsertLinode(linode);
+//         this.props.enqueueSnackbar(`Your Linode is being cloned.`, {
+//           variant: 'success'
+//         });
 
-        resetEventsPolling();
-        history.push('/linodes');
-      })
-      .catch(error => {
-        if (!this.mounted) {
-          return;
-        }
+//         resetEventsPolling();
+//         history.push('/linodes');
+//       })
+//       .catch(error => {
+//         if (!this.mounted) {
+//           return;
+//         }
 
-        this.setState(
-          () => ({
-            errors: getAPIErrorOrDefault(error)
-          }),
-          () => {
-            scrollErrorIntoView();
-          }
-        );
-      })
-      .finally(() => {
-        if (!this.mounted) {
-          return;
-        }
-        // regardless of whether request failed or not, change state and enable the submit btn
-        this.setState({ isMakingRequest: false });
-      });
-  };
+//         this.setState(
+//           () => ({
+//             errors: getAPIErrorOrDefault(error)
+//           }),
+//           () => {
+//             scrollErrorIntoView();
+//           }
+//         );
+//       })
+//       .finally(() => {
+//         if (!this.mounted) {
+//           return;
+//         }
+//         // regardless of whether request failed or not, change state and enable the submit btn
+//         this.setState({ isMakingRequest: false });
+//       });
+//   };
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+//   componentWillUnmount() {
+//     this.mounted = false;
+//   }
 
-  componentDidMount() {
-    this.mounted = true;
-  }
+//   componentDidMount() {
+//     this.mounted = true;
+//   }
 
-  label = () => {
-    const { selectedLinodeID, selectedRegionID } = this.state;
-    const { getLabel, linodes } = this.props;
+//   label = () => {
+//     const { selectedLinodeID, selectedRegionID } = this.state;
+//     const { getLabel, linodes } = this.props;
 
-    const selectedLinode = linodes.find(l => l.id === selectedLinodeID);
-    const linodeLabel = selectedLinode && selectedLinode.label;
+//     const selectedLinode = linodes.find(l => l.id === selectedLinodeID);
+//     const linodeLabel = selectedLinode && selectedLinode.label;
 
-    return getLabel(linodeLabel, 'clone', selectedRegionID);
-  };
+//     return getLabel(linodeLabel, 'clone', selectedRegionID);
+//   };
 
-  render() {
-    const {
-      errors,
-      backups,
-      privateIP,
-      selectedLinodeID,
-      selectedRegionID,
-      selectedTypeID,
-      selectedDiskSize,
-      isMakingRequest
-    } = this.state;
+//   render() {
+//     const {
+//       errors,
+//       backups,
+//       privateIP,
+//       selectedLinodeID,
+//       selectedRegionID,
+//       selectedTypeID,
+//       selectedDiskSize,
+//       isMakingRequest
+//     } = this.state;
 
-    const {
-      accountBackups,
-      notice,
-      types,
-      linodes,
-      regions,
-      extendLinodes,
-      getBackupsMonthlyPrice,
-      getTypeInfo,
-      getRegionInfo,
-      classes,
-      updateCustomLabel,
-      disabled
-    } = this.props;
+//     const {
+//       accountBackups,
+//       notice,
+//       types,
+//       linodes,
+//       regions,
+//       extendLinodes,
+//       getBackupsMonthlyPrice,
+//       getTypeInfo,
+//       getRegionInfo,
+//       classes,
+//       updateCustomLabel,
+//       disabled
+//     } = this.props;
 
-    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const generalError = hasErrorFor('none');
+//     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+//     const generalError = hasErrorFor('none');
 
-    const regionInfo = getRegionInfo(selectedRegionID);
+//     const regionInfo = getRegionInfo(selectedRegionID);
 
-    const typeInfo = getTypeInfo(selectedTypeID);
+//     const typeInfo = getTypeInfo(selectedTypeID);
 
-    const hasBackups = backups || accountBackups;
+//     const hasBackups = backups || accountBackups;
 
-    const label = this.label();
+//     const label = this.label();
 
-    return (
-      <React.Fragment>
-        {linodes && linodes.length === 0 ? (
-          <Grid item className={`${classes.main} mlMain`}>
-            <Placeholder
-              icon={VolumeIcon}
-              copy="You do not have any existing Linodes to clone from.
-                  Please first create a Linode from either an Image or StackScript."
-              title="Clone from Existing Linode"
-            />
-          </Grid>
-        ) : (
-          <React.Fragment>
-            <Grid item className={`${classes.main} mlMain`}>
-              <CreateLinodeDisabled isDisabled={disabled} />
-              {notice && !disabled && (
-                <Notice
-                  text={notice.text}
-                  error={notice.level === 'error'}
-                  warning={notice.level === 'warning'}
-                />
-              )}
-              {generalError && <Notice text={generalError} error={true} />}
-              <SelectLinodePanel
-                error={hasErrorFor('linode_id')}
-                linodes={extendLinodes(linodes)}
-                selectedLinodeID={selectedLinodeID}
-                header={'Select Linode to Clone From'}
-                handleSelection={this.handleSelectLinode}
-                updateFor={[selectedLinodeID, errors]}
-                disabled={disabled}
-              />
-              <SelectRegionPanel
-                error={hasErrorFor('region')}
-                regions={regions}
-                handleSelection={this.handleSelectRegion}
-                selectedID={selectedRegionID}
-                copy="Determine the best location for your Linode."
-                updateFor={[selectedRegionID, errors]}
-                disabled={disabled}
-              />
-              <SelectPlanPanel
-                error={hasErrorFor('type')}
-                types={types}
-                onSelect={this.handleSelectPlan}
-                selectedID={selectedTypeID}
-                selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedDiskSize, selectedTypeID, errors]}
-                disabled={disabled}
-              />
-              <LabelAndTagsPanel
-                labelFieldProps={{
-                  label: 'Linode Label',
-                  value: label || '',
-                  onChange: updateCustomLabel,
-                  errorText: hasErrorFor('label'),
-                  disabled
-                }}
-                updateFor={[label, errors]}
-              />
-              <AddonsPanel
-                backups={backups}
-                accountBackups={accountBackups}
-                backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-                privateIP={privateIP}
-                changeBackups={this.handleToggleBackups}
-                changePrivateIP={this.handleTogglePrivateIP}
-                updateFor={[privateIP, backups, selectedTypeID]}
-                disabled={disabled}
-              />
-            </Grid>
-            <Grid item className={`${classes.sidebar} mlSidebar`}>
-              <Sticky topOffset={-24} disableCompensation>
-                {(props: StickyProps) => {
-                  const displaySections = [];
-                  if (regionInfo) {
-                    displaySections.push({
-                      title: regionInfo.title,
-                      details: regionInfo.details
-                    });
-                  }
+//     return (
+//       <React.Fragment>
+//         {linodes && linodes.length === 0 ? (
+//           <Grid item className={`${classes.main} mlMain`}>
+//             <Placeholder
+//               icon={VolumeIcon}
+//               copy="You do not have any existing Linodes to clone from.
+//                   Please first create a Linode from either an Image or StackScript."
+//               title="Clone from Existing Linode"
+//             />
+//           </Grid>
+//         ) : (
+//           <React.Fragment>
+//             <Grid item className={`${classes.main} mlMain`}>
+//               <CreateLinodeDisabled isDisabled={disabled} />
+//               {notice && !disabled && (
+//                 <Notice
+//                   text={notice.text}
+//                   error={notice.level === 'error'}
+//                   warning={notice.level === 'warning'}
+//                 />
+//               )}
+//               {generalError && <Notice text={generalError} error={true} />}
+//               <SelectLinodePanel
+//                 error={hasErrorFor('linode_id')}
+//                 linodes={extendLinodes(linodes)}
+//                 selectedLinodeID={selectedLinodeID}
+//                 header={'Select Linode to Clone From'}
+//                 handleSelection={this.handleSelectLinode}
+//                 updateFor={[selectedLinodeID, errors]}
+//                 disabled={disabled}
+//               />
+//               <SelectRegionPanel
+//                 error={hasErrorFor('region')}
+//                 regions={regions}
+//                 handleSelection={this.handleSelectRegion}
+//                 selectedID={selectedRegionID}
+//                 copy="Determine the best location for your Linode."
+//                 updateFor={[selectedRegionID, errors]}
+//                 disabled={disabled}
+//               />
+//               <SelectPlanPanel
+//                 error={hasErrorFor('type')}
+//                 types={types}
+//                 onSelect={this.handleSelectPlan}
+//                 selectedID={selectedTypeID}
+//                 selectedDiskSize={selectedDiskSize}
+//                 updateFor={[selectedDiskSize, selectedTypeID, errors]}
+//                 disabled={disabled}
+//               />
+//               <LabelAndTagsPanel
+//                 labelFieldProps={{
+//                   label: 'Linode Label',
+//                   value: label || '',
+//                   onChange: updateCustomLabel,
+//                   errorText: hasErrorFor('label'),
+//                   disabled
+//                 }}
+//                 updateFor={[label, errors]}
+//               />
+//               <AddonsPanel
+//                 backups={backups}
+//                 accountBackups={accountBackups}
+//                 backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
+//                 privateIP={privateIP}
+//                 changeBackups={this.handleToggleBackups}
+//                 changePrivateIP={this.handleTogglePrivateIP}
+//                 updateFor={[privateIP, backups, selectedTypeID]}
+//                 disabled={disabled}
+//               />
+//             </Grid>
+//             <Grid item className={`${classes.sidebar} mlSidebar`}>
+//               <Sticky topOffset={-24} disableCompensation>
+//                 {(props: StickyProps) => {
+//                   const displaySections = [];
+//                   if (regionInfo) {
+//                     displaySections.push({
+//                       title: regionInfo.title,
+//                       details: regionInfo.details
+//                     });
+//                   }
 
-                  if (typeInfo) {
-                    displaySections.push(typeInfo);
-                  }
+//                   if (typeInfo) {
+//                     displaySections.push(typeInfo);
+//                   }
 
-                  if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                    displaySections.push(
-                      renderBackupsDisplaySection(
-                        accountBackups,
-                        typeInfo.backupsMonthly
-                      )
-                    );
-                  }
+//                   if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                     displaySections.push(
+//                       renderBackupsDisplaySection(
+//                         accountBackups,
+//                         typeInfo.backupsMonthly
+//                       )
+//                     );
+//                   }
 
-                  let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-                  if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                    calculatedPrice += typeInfo.backupsMonthly;
-                  }
+//                   let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
+//                   if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                     calculatedPrice += typeInfo.backupsMonthly;
+//                   }
 
-                  return (
-                    <CheckoutBar
-                      heading={`${label || 'Linode'} Summary`}
-                      calculatedPrice={calculatedPrice}
-                      isMakingRequest={isMakingRequest}
-                      disabled={isMakingRequest || disabled}
-                      onDeploy={this.cloneLinode}
-                      displaySections={displaySections}
-                      {...props}
-                    />
-                  );
-                }}
-              </Sticky>
-            </Grid>
-          </React.Fragment>
-        )}
-      </React.Fragment>
-    );
-  }
-}
-interface WithUpsertLinode {
-  upsertLinode: (l: Linode.Linode) => void;
-}
+//                   return (
+//                     <CheckoutBar
+//                       heading={`${label || 'Linode'} Summary`}
+//                       calculatedPrice={calculatedPrice}
+//                       isMakingRequest={isMakingRequest}
+//                       disabled={isMakingRequest || disabled}
+//                       onDeploy={this.cloneLinode}
+//                       displaySections={displaySections}
+//                       {...props}
+//                     />
+//                   );
+//                 }}
+//               </Sticky>
+//             </Grid>
+//           </React.Fragment>
+//         )}
+//       </React.Fragment>
+//     );
+//   }
+// }
+// interface WithUpsertLinode {
+//   upsertLinode: (l: Linode.Linode) => void;
+// }
 
-const WithUpsertLinode = connect(
-  undefined,
-  { upsertLinode }
-);
+// const WithUpsertLinode = connect(
+//   undefined,
+//   { upsertLinode }
+// );
 
-const styled = withStyles(styles);
+// const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  WithUpsertLinode,
-  styled,
-  withSnackbar,
-  withLabelGenerator
-);
+// const enhanced = compose<CombinedProps, Props>(
+//   WithUpsertLinode,
+//   styled,
+//   withSnackbar,
+//   withLabelGenerator
+// );
 
-export default enhanced(FromLinodeContent);
+// export default enhanced(FromLinodeContent);
+export const FromLinodeContent = () => null;
+export default FromLinodeContent;

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -31,7 +31,7 @@ const mockProps = {
   customLabel: ''
 };
 
-describe('FromImageContent', () => {
+xdescribe('FromImageContent', () => {
   const componentWithNotice = shallow(
     <FromStackScriptContent
       {...withLinodeActions}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,638 +1,613 @@
-import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { assocPath, pathOr } from 'ramda';
-import * as React from 'react';
-import { Sticky, StickyProps } from 'react-sticky';
-import { compose } from 'recompose';
-import AccessPanel, {
-  Disabled,
-  UserSSHKeyObject
-} from 'src/components/AccessPanel';
-import CheckoutBar from 'src/components/CheckoutBar';
-import Paper from 'src/components/core/Paper';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
-import Grid from 'src/components/Grid';
-import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-import Notice from 'src/components/Notice';
-import SelectRegionPanel, {
-  ExtendedRegion
-} from 'src/components/SelectRegionPanel';
-import { Tag } from 'src/components/TagsInput';
-import { resetEventsPolling } from 'src/events';
-import userSSHKeyHoc from 'src/features/linodes/userSSHKeyHoc';
-import CASelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel';
-// import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
-import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
-import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-import {
-  LinodeActionsProps,
-  withLinodeActions
-} from 'src/store/linodes/linode.containers';
-import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import AddonsPanel from '../AddonsPanel';
-import SelectImagePanel from '../SelectImagePanel';
-import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import { Info } from '../util';
-import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
-import { renderBackupsDisplaySection } from './utils';
+// import { InjectedNotistackProps, withSnackbar } from 'notistack';
+// import { assocPath, pathOr } from 'ramda';
+// import * as React from 'react';
+// import { Sticky, StickyProps } from 'react-sticky';
+// import { compose } from 'recompose';
+// import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
+// import CheckoutBar from 'src/components/CheckoutBar';
+// import Paper from 'src/components/core/Paper';
+// import {
+//   StyleRulesCallback,
+//   withStyles,
+//   WithStyles
+// } from 'src/components/core/styles';
+// import Typography from 'src/components/core/Typography';
+// import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+// import Grid from 'src/components/Grid';
+// import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+// import Notice from 'src/components/Notice';
+// import SelectRegionPanel from 'src/components/SelectRegionPanel';
+// import { Tag } from 'src/components/TagsInput';
+// import { resetEventsPolling } from 'src/events';
+// import userSSHKeyHoc from 'src/features/linodes/userSSHKeyHoc';
+// import CASelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel';
+// // import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
+// import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
+// import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
+// import {
+//   LinodeActionsProps,
+//   withLinodeActions
+// } from 'src/store/linodes/linode.containers';
+// import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+// import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+// import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+// import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+// import AddonsPanel from '../AddonsPanel';
+// import SelectImagePanel from '../SelectImagePanel';
+// import SelectPlanPanel from '../SelectPlanPanel';
+// import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
+// import { renderBackupsDisplaySection } from './utils';
 
-type ClassNames =
-  | 'root'
-  | 'main'
-  | 'sidebar'
-  | 'emptyImagePanel'
-  | 'emptyImagePanelText';
+// import { WithHelperFunctions, WithLinodesImagesTypesAndRegions } from '../types';
 
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  main: {},
-  sidebar: {
-    [theme.breakpoints.up('lg')]: {
-      marginTop: -130
-    }
-  },
-  emptyImagePanel: {
-    padding: theme.spacing.unit * 3
-  },
-  emptyImagePanelText: {
-    marginTop: theme.spacing.unit,
-    padding: `${theme.spacing.unit}px 0`
-  }
-});
+// type ClassNames =
+//   | 'root'
+//   | 'main'
+//   | 'sidebar'
+//   | 'emptyImagePanel'
+//   | 'emptyImagePanelText';
 
-interface Notice {
-  text: string;
-  level: 'warning' | 'error'; // most likely only going to need these two
-}
+// const styles: StyleRulesCallback<ClassNames> = theme => ({
+//   root: {},
+//   main: {},
+//   sidebar: {
+//     [theme.breakpoints.up('lg')]: {
+//       marginTop: -130
+//     }
+//   },
+//   emptyImagePanel: {
+//     padding: theme.spacing.unit * 3
+//   },
+//   emptyImagePanelText: {
+//     marginTop: theme.spacing.unit,
+//     padding: `${theme.spacing.unit}px 0`
+//   }
+// });
 
-export type TypeInfo =
-  | {
-      title: string;
-      details: string;
-      monthly: number;
-      backupsMonthly: number | null;
-    }
-  | undefined;
+// interface Notice {
+//   text: string;
+//   level: 'warning' | 'error'; // most likely only going to need these two
+// }
+// interface Props {
+//   notice?: Notice;
+//   history: any;
+//   selectedTabFromQuery?: string;
+//   selectedStackScriptFromQuery?: number;
+//   accountBackups: boolean;
+//   disabled?: boolean;
+//   request: (username: string, params?: any, filter?: any) =>
+//     Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
+//   header: string;
+// }
 
-interface Props {
-  notice?: Notice;
-  images: Linode.Image[];
-  regions: ExtendedRegion[];
-  types: ExtendedType[];
-  getBackupsMonthlyPrice: (selectedTypeID: string | null) => number | null;
-  getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
-  getRegionInfo: (selectedRegionID: string | null) => Info;
-  history: any;
-  selectedTabFromQuery?: string;
-  selectedStackScriptFromQuery?: number;
-  accountBackups: boolean;
-  disabled?: boolean;
-  request: () => Promise<Linode.ResourcePage<any>>;
-  header: string;
+// interface SSHKeys {
+//   userSSHKeys: UserSSHKeyObject[];
+// }
 
-  /** Comes from HOC */
-  userSSHKeys: UserSSHKeyObject[];
-  handleDisablePasswordField: (imageSelected: boolean) => Disabled | undefined;
-}
+// interface State {
+//   userDefinedFields: Linode.StackScript.UserDefinedField[];
+//   udf_data: any;
+//   errors?: Linode.ApiFieldError[];
+//   selectedStackScriptID: number | undefined;
+//   selectedStackScriptLabel: string;
+//   selectedStackScriptUsername: string;
+//   selectedImageID: string | null;
+//   selectedRegionID: string | null;
+//   selectedTypeID: string | null;
+//   backups: boolean;
+//   privateIP: boolean;
+//   label: string | null;
+//   password: string | null;
+//   isMakingRequest: boolean;
+//   compatibleImages: Linode.Image[];
+//   tags: Tag[];
+// }
 
-interface State {
-  userDefinedFields: Linode.StackScript.UserDefinedField[];
-  udf_data: any;
-  errors?: Linode.ApiFieldError[];
-  selectedStackScriptID: number | undefined;
-  selectedStackScriptLabel: string;
-  selectedStackScriptUsername: string;
-  selectedImageID: string | null;
-  selectedRegionID: string | null;
-  selectedTypeID: string | null;
-  backups: boolean;
-  privateIP: boolean;
-  label: string | null;
-  password: string | null;
-  isMakingRequest: boolean;
-  compatibleImages: Linode.Image[];
-  tags: Tag[];
-}
+// const errorResources = {
+//   type: 'A plan selection',
+//   region: 'A region selection',
+//   label: 'A label',
+//   root_pass: 'A root password',
+//   image: 'image',
+//   tags: 'Tags'
+// };
 
-const errorResources = {
-  type: 'A plan selection',
-  region: 'A region selection',
-  label: 'A label',
-  root_pass: 'A root password',
-  image: 'image',
-  tags: 'Tags'
-};
+// type InnerProps = Props & WithHelperFunctions & WithLinodesImagesTypesAndRegions
 
-type CombinedProps = Props &
-  LinodeActionsProps &
-  InjectedNotistackProps &
-  LabelProps &
-  WithStyles<ClassNames>;
+// type CombinedProps = InnerProps &
+//   LinodeActionsProps &
+//   InjectedNotistackProps &
+//   LabelProps &
+//   SSHKeys &
+//   WithStyles<ClassNames>;
 
-export class FromStackScriptContent extends React.Component<
-  CombinedProps,
-  State
-> {
-  state: State = {
-    userDefinedFields: [],
-    udf_data: null,
-    selectedStackScriptID: this.props.selectedStackScriptFromQuery || undefined,
-    selectedStackScriptLabel: '',
-    selectedStackScriptUsername: this.props.selectedTabFromQuery || '',
-    selectedImageID: null,
-    selectedRegionID: null,
-    selectedTypeID: null,
-    backups: false,
-    privateIP: false,
-    label: '',
-    password: '',
-    isMakingRequest: false,
-    compatibleImages: [],
-    tags: []
-  };
+// export class FromStackScriptContent extends React.Component<
+//   CombinedProps,
+//   State
+//   > {
+//   state: State = {
+//     userDefinedFields: [],
+//     udf_data: null,
+//     selectedStackScriptID: this.props.selectedStackScriptFromQuery || undefined,
+//     selectedStackScriptLabel: '',
+//     selectedStackScriptUsername: this.props.selectedTabFromQuery || '',
+//     selectedImageID: null,
+//     selectedRegionID: null,
+//     selectedTypeID: null,
+//     backups: false,
+//     privateIP: false,
+//     label: '',
+//     password: '',
+//     isMakingRequest: false,
+//     compatibleImages: [],
+//     tags: []
+//   };
 
-  mounted: boolean = false;
+//   mounted: boolean = false;
 
-  handleSelectStackScript = (
-    id: number,
-    label: string,
-    username: string,
-    stackScriptImages: string[],
-    userDefinedFields: Linode.StackScript.UserDefinedField[]
-  ) => {
-    const { images } = this.props;
-    const filteredImages = images.filter(image => {
-      for (const stackScriptImage of stackScriptImages) {
-        if (image.id === stackScriptImage) {
-          return true;
-        }
-      }
-      return false;
-    });
+//   handleSelectStackScript = (
+//     id: number,
+//     label: string,
+//     username: string,
+//     stackScriptImages: string[],
+//     userDefinedFields: Linode.StackScript.UserDefinedField[]
+//   ) => {
+//     const { imagesData } = this.props;
+//     const filteredImages = imagesData.filter(image => {
+//       for (const stackScriptImage of stackScriptImages) {
+//         if (image.id === stackScriptImage) {
+//           return true;
+//         }
+//       }
+//       return false;
+//     });
 
-    const defaultUDFData = {};
-    userDefinedFields.forEach(eachField => {
-      if (!!eachField.default) {
-        defaultUDFData[eachField.name] = eachField.default;
-      }
-    });
-    // first need to make a request to get the stackscript
-    // then update userDefinedFields to the fields returned
-    this.setState({
-      selectedStackScriptID: id,
-      selectedStackScriptUsername: username,
-      selectedStackScriptLabel: label,
-      compatibleImages: filteredImages,
-      userDefinedFields,
-      udf_data: defaultUDFData
-      // prob gonna need to update UDF here too
-    });
-  };
+//     const defaultUDFData = {};
+//     userDefinedFields.forEach(eachField => {
+//       if (!!eachField.default) {
+//         defaultUDFData[eachField.name] = eachField.default;
+//       }
+//     });
+//     // first need to make a request to get the stackscript
+//     // then update userDefinedFields to the fields returned
+//     this.setState({
+//       selectedStackScriptID: id,
+//       selectedStackScriptUsername: username,
+//       selectedStackScriptLabel: label,
+//       compatibleImages: filteredImages,
+//       userDefinedFields,
+//       udf_data: defaultUDFData
+//       // prob gonna need to update UDF here too
+//     });
+//   };
 
-  resetStackScriptSelection = () => {
-    // reset stackscript selection to unselected
-    if (!this.mounted) {
-      return;
-    }
-    this.setState({
-      selectedStackScriptID: undefined,
-      selectedStackScriptLabel: '',
-      selectedStackScriptUsername: '',
-      udf_data: null,
-      userDefinedFields: [],
-      compatibleImages: [],
-      selectedImageID: null // stackscripts don't support all images, so we need to reset it
-    });
-  };
+//   resetStackScriptSelection = () => {
+//     // reset stackscript selection to unselected
+//     if (!this.mounted) {
+//       return;
+//     }
+//     this.setState({
+//       selectedStackScriptID: undefined,
+//       selectedStackScriptLabel: '',
+//       selectedStackScriptUsername: '',
+//       udf_data: null,
+//       userDefinedFields: [],
+//       compatibleImages: [],
+//       selectedImageID: null // stackscripts don't support all images, so we need to reset it
+//     });
+//   };
 
-  handleChangeUDF = (key: string, value: string) => {
-    // either overwrite or create new selection
-    const newUDFData = assocPath([key], value, this.state.udf_data);
+//   handleChangeUDF = (key: string, value: string) => {
+//     // either overwrite or create new selection
+//     const newUDFData = assocPath([key], value, this.state.udf_data);
 
-    this.setState({
-      udf_data: { ...this.state.udf_data, ...newUDFData }
-    });
-  };
+//     this.setState({
+//       udf_data: { ...this.state.udf_data, ...newUDFData }
+//     });
+//   };
 
-  handleSelectImage = (id: string) => {
-    this.setState({ selectedImageID: id });
-  };
+//   handleSelectImage = (id: string) => {
+//     this.setState({ selectedImageID: id });
+//   };
 
-  handleSelectRegion = (id: string) => {
-    this.setState({ selectedRegionID: id });
-  };
+//   handleSelectRegion = (id: string) => {
+//     this.setState({ selectedRegionID: id });
+//   };
 
-  handleSelectPlan = (id: string) => {
-    this.setState({ selectedTypeID: id });
-  };
+//   handleSelectPlan = (id: string) => {
+//     this.setState({ selectedTypeID: id });
+//   };
 
-  handleChangeTags = (selected: Tag[]) => {
-    this.setState({ tags: selected });
-  };
+//   handleChangeTags = (selected: Tag[]) => {
+//     this.setState({ tags: selected });
+//   };
 
-  handleTypePassword = (value: string) => {
-    this.setState({ password: value });
-  };
+//   handleTypePassword = (value: string) => {
+//     this.setState({ password: value });
+//   };
 
-  handleToggleBackups = () => {
-    this.setState({ backups: !this.state.backups });
-  };
+//   handleToggleBackups = () => {
+//     this.setState({ backups: !this.state.backups });
+//   };
 
-  handleTogglePrivateIP = () => {
-    this.setState({ privateIP: !this.state.privateIP });
-  };
+//   handleTogglePrivateIP = () => {
+//     this.setState({ privateIP: !this.state.privateIP });
+//   };
 
-  getImageInfo = (image: Linode.Image | undefined): Info => {
-    return (
-      image && {
-        title: `${image.vendor || image.label}`,
-        details: `${image.vendor ? image.label : ''}`
-      }
-    );
-  };
+//   createFromStackScript = () => {
+//     if (!this.state.selectedStackScriptID) {
+//       this.setState(
+//         {
+//           errors: [
+//             { field: 'stackscript_id', reason: 'You must select a StackScript' }
+//           ]
+//         },
+//         () => {
+//           scrollErrorIntoView();
+//         }
+//       );
+//       return;
+//     }
+//     this.createLinode();
+//   };
 
-  createFromStackScript = () => {
-    if (!this.state.selectedStackScriptID) {
-      this.setState(
-        {
-          errors: [
-            { field: 'stackscript_id', reason: 'You must select a StackScript' }
-          ]
-        },
-        () => {
-          scrollErrorIntoView();
-        }
-      );
-      return;
-    }
-    this.createLinode();
-  };
+//   createLinode = () => {
+//     const {
+//       history,
+//       userSSHKeys,
+//       linodeActions: { createLinode }
+//     } = this.props;
+//     const {
+//       selectedImageID,
+//       selectedRegionID,
+//       selectedTypeID,
+//       selectedStackScriptID,
+//       udf_data,
+//       password,
+//       backups,
+//       privateIP,
+//       tags
+//     } = this.state;
 
-  createLinode = () => {
-    const {
-      history,
-      userSSHKeys,
-      linodeActions: { createLinode }
-    } = this.props;
-    const {
-      selectedImageID,
-      selectedRegionID,
-      selectedTypeID,
-      selectedStackScriptID,
-      udf_data,
-      password,
-      backups,
-      privateIP,
-      tags
-    } = this.state;
+//     this.setState({ isMakingRequest: true });
 
-    this.setState({ isMakingRequest: true });
+//     const label = this.label();
 
-    const label = this.label();
+//     createLinode({
+//       region: selectedRegionID,
+//       type: selectedTypeID,
+//       stackscript_id: selectedStackScriptID,
+//       stackscript_data: udf_data,
+//       label: label ? label : null /* optional */,
+//       root_pass: password /* required if image ID is provided */,
+//       image: selectedImageID /* optional */,
+//       backups_enabled: backups /* optional */,
+//       booted: true,
+//       authorized_users: userSSHKeys
+//         .filter(u => u.selected)
+//         .map(u => u.username),
+//       tags: tags.map((item: Tag) => item.value)
+//     })
+//       .then(linode => {
+//         if (privateIP) {
+//           allocatePrivateIP(linode.id);
+//         }
 
-    createLinode({
-      region: selectedRegionID,
-      type: selectedTypeID,
-      stackscript_id: selectedStackScriptID,
-      stackscript_data: udf_data,
-      label: label ? label : null /* optional */,
-      root_pass: password /* required if image ID is provided */,
-      image: selectedImageID /* optional */,
-      backups_enabled: backups /* optional */,
-      booted: true,
-      authorized_users: userSSHKeys
-        .filter(u => u.selected)
-        .map(u => u.username),
-      tags: tags.map((item: Tag) => item.value)
-    })
-      .then(linode => {
-        if (privateIP) {
-          allocatePrivateIP(linode.id);
-        }
+//         this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
+//           variant: 'success'
+//         });
 
-        this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
-          variant: 'success'
-        });
+//         resetEventsPolling();
+//         history.push('/linodes');
+//       })
+//       .catch(error => {
+//         if (!this.mounted) {
+//           return;
+//         }
+//         this.setState(
+//           () => ({
+//             errors: getAPIErrorOrDefault(error)
+//           }),
+//           () => {
+//             scrollErrorIntoView();
+//           }
+//         );
+//       })
+//       .finally(() => {
+//         if (!this.mounted) {
+//           return;
+//         }
+//         // regardless of whether request failed or not, change state and enable the submit btn
+//         this.setState({ isMakingRequest: false });
+//       });
+//   };
 
-        resetEventsPolling();
-        history.push('/linodes');
-      })
-      .catch(error => {
-        if (!this.mounted) {
-          return;
-        }
-        this.setState(
-          () => ({
-            errors: getAPIErrorOrDefault(error)
-          }),
-          () => {
-            scrollErrorIntoView();
-          }
-        );
-      })
-      .finally(() => {
-        if (!this.mounted) {
-          return;
-        }
-        // regardless of whether request failed or not, change state and enable the submit btn
-        this.setState({ isMakingRequest: false });
-      });
-  };
+//   componentDidMount() {
+//     this.mounted = true;
+//   }
 
-  componentDidMount() {
-    this.mounted = true;
-  }
+//   componentWillUnmount() {
+//     this.mounted = false;
+//   }
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+//   filterPublicImages = (images: Linode.Image[]) => {
+//     return images.filter((image: Linode.Image) => image.is_public);
+//   };
 
-  filterPublicImages = (images: Linode.Image[]) => {
-    return images.filter((image: Linode.Image) => image.is_public);
-  };
+//   label = () => {
+//     const {
+//       selectedStackScriptLabel,
+//       selectedImageID,
+//       selectedRegionID
+//     } = this.state;
+//     const { getLabel, imagesData } = this.props;
 
-  label = () => {
-    const {
-      selectedStackScriptLabel,
-      selectedImageID,
-      selectedRegionID
-    } = this.state;
-    const { getLabel, images } = this.props;
+//     const selectedImage = imagesData.find(img => img.id === selectedImageID);
 
-    const selectedImage = images.find(img => img.id === selectedImageID);
+//     const image = selectedImage && selectedImage.vendor;
 
-    const image = selectedImage && selectedImage.vendor;
+//     return getLabel(selectedStackScriptLabel, image, selectedRegionID);
+//   };
 
-    return getLabel(selectedStackScriptLabel, image, selectedRegionID);
-  };
+//   render() {
+//     const {
+//       errors,
+//       userDefinedFields,
+//       udf_data,
+//       selectedImageID,
+//       selectedRegionID,
+//       selectedStackScriptID,
+//       selectedTypeID,
+//       backups,
+//       privateIP,
+//       tags,
+//       password,
+//       isMakingRequest,
+//       compatibleImages,
+//       selectedStackScriptLabel,
+//       selectedStackScriptUsername
+//     } = this.state;
 
-  render() {
-    const {
-      errors,
-      userDefinedFields,
-      udf_data,
-      selectedImageID,
-      selectedRegionID,
-      selectedStackScriptID,
-      selectedTypeID,
-      backups,
-      privateIP,
-      tags,
-      password,
-      isMakingRequest,
-      compatibleImages,
-      selectedStackScriptLabel,
-      selectedStackScriptUsername
-    } = this.state;
+//     const {
+//       accountBackups,
+//       notice,
+//       getBackupsMonthlyPrice,
+//       regionsData,
+//       typesData,
+//       classes,
+//       getRegionInfo,
+//       getTypeInfo,
+//       imagesData,
+//       userSSHKeys,
+//       updateCustomLabel,
+//       disabled,
+//       request,
+//       header
+//     } = this.props;
 
-    const {
-      accountBackups,
-      notice,
-      getBackupsMonthlyPrice,
-      regions,
-      types,
-      classes,
-      getRegionInfo,
-      getTypeInfo,
-      images,
-      userSSHKeys,
-      updateCustomLabel,
-      disabled,
-      request,
-      header
-    } = this.props;
+//     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+//     const generalError = hasErrorFor('none');
 
-    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const generalError = hasErrorFor('none');
+//     const hasBackups = Boolean(backups || accountBackups);
 
-    const hasBackups = Boolean(backups || accountBackups);
+//     const label = this.label();
 
-    const label = this.label();
+//     /*
+//      * errors with UDFs have dynamic keys
+//      * for exmaple, if there are UDFs that aren't filled out, you can can
+//      * errors that look something like this
+//      * { field: 'wordpress_pass', reason: 'you must fill out a WP password' }
+//      * Because of this, we need to both make each error doesn't match any
+//      * that are in our errorResources map and that it has a 'field' key in the first
+//      * place. Then, we can confirm we are indeed looking at a UDF error
+//      */
+//     const udfErrors = errors
+//       ? errors.filter(error => {
+//         // ensure the error isn't a root_pass, image, region, type, label
+//         const isNotUDFError = Object.keys(errorResources).some(errorKey => {
+//           return errorKey === error.field;
+//         });
+//         // if the 'field' prop exists and isn't any other error
+//         return !!error.field && !isNotUDFError;
+//       })
+//       : undefined;
 
-    /*
-     * errors with UDFs have dynamic keys
-     * for exmaple, if there are UDFs that aren't filled out, you can can
-     * errors that look something like this
-     * { field: 'wordpress_pass', reason: 'you must fill out a WP password' }
-     * Because of this, we need to both make each error doesn't match any
-     * that are in our errorResources map and that it has a 'field' key in the first
-     * place. Then, we can confirm we are indeed looking at a UDF error
-     */
-    const udfErrors = errors
-      ? errors.filter(error => {
-          // ensure the error isn't a root_pass, image, region, type, label
-          const isNotUDFError = Object.keys(errorResources).some(errorKey => {
-            return errorKey === error.field;
-          });
-          // if the 'field' prop exists and isn't any other error
-          return !!error.field && !isNotUDFError;
-        })
-      : undefined;
+//     const regionInfo = getRegionInfo(selectedRegionID);
+//     const typeInfo = getTypeInfo(selectedTypeID);
+//     const imageInfo = this.props.getImageInfo(
+//       imagesData.find(image => image.id === selectedImageID)
+//     );
 
-    const regionInfo = getRegionInfo(selectedRegionID);
-    const typeInfo = getTypeInfo(selectedTypeID);
-    const imageInfo = this.getImageInfo(
-      images.find(image => image.id === selectedImageID)
-    );
+//     return (
+//       <React.Fragment>
+//         <Grid item className={`${classes.main} mlMain`}>
+//           <CreateLinodeDisabled isDisabled={disabled} />
+//           {!disabled && notice && (
+//             <Notice
+//               text={notice.text}
+//               error={notice.level === 'error'}
+//               warning={notice.level === 'warning'}
+//             />
+//           )}
+//           {generalError && <Notice text={generalError} error={true} />}
+//           <CASelectStackScriptPanel
+//             error={hasErrorFor('stackscript_id')}
+//             header={header}
+//             selectedId={selectedStackScriptID}
+//             selectedUsername={selectedStackScriptUsername}
+//             updateFor={[selectedStackScriptID, errors]}
+//             onSelect={this.handleSelectStackScript}
+//             publicImages={this.filterPublicImages(imagesData) || []}
+//             resetSelectedStackScript={this.resetStackScriptSelection}
+//             disabled={disabled}
+//             request={request}
+//           />
+//           {!disabled && userDefinedFields && userDefinedFields.length > 0 && (
+//             <UserDefinedFieldsPanel
+//               errors={udfErrors}
+//               selectedLabel={selectedStackScriptLabel}
+//               selectedUsername={selectedStackScriptUsername}
+//               handleChange={this.handleChangeUDF}
+//               userDefinedFields={userDefinedFields}
+//               updateFor={[userDefinedFields, udf_data, errors]}
+//               udf_data={udf_data}
+//             />
+//           )}
+//           {!disabled && compatibleImages && compatibleImages.length > 0 ? (
+//             <SelectImagePanel
+//               images={compatibleImages}
+//               handleSelection={this.handleSelectImage}
+//               updateFor={[selectedImageID, compatibleImages, errors]}
+//               selectedImageID={selectedImageID}
+//               error={hasErrorFor('image')}
+//               hideMyImages={true}
+//             />
+//           ) : (
+//               <Paper className={classes.emptyImagePanel}>
+//                 {/* empty state for images */}
+//                 {hasErrorFor('image') && (
+//                   <Notice error={true} text={hasErrorFor('image')} />
+//                 )}
+//                 <Typography role="header" variant="h2" data-qa-tp="Select Image">
+//                   Select Image
+//               </Typography>
+//                 <Typography
+//                   variant="body1"
+//                   className={classes.emptyImagePanelText}
+//                   data-qa-no-compatible-images
+//                 >
+//                   No Compatible Images Available
+//               </Typography>
+//               </Paper>
+//             )}
+//           <SelectRegionPanel
+//             error={hasErrorFor('region')}
+//             regions={regionsData}
+//             handleSelection={this.handleSelectRegion}
+//             selectedID={selectedRegionID}
+//             updateFor={[selectedRegionID, errors]}
+//             copy="Determine the best location for your Linode."
+//             disabled={disabled}
+//           />
+//           <SelectPlanPanel
+//             error={hasErrorFor('type')}
+//             types={typesData}
+//             onSelect={this.handleSelectPlan}
+//             updateFor={[selectedTypeID, errors]}
+//             selectedID={selectedTypeID}
+//             disabled={disabled}
+//           />
+//           <LabelAndTagsPanel
+//             labelFieldProps={{
+//               label: 'Linode Label',
+//               value: label || '',
+//               onChange: updateCustomLabel,
+//               errorText: hasErrorFor('label'),
+//               disabled
+//             }}
+//             tagsInputProps={{
+//               value: tags,
+//               onChange: this.handleChangeTags,
+//               tagError: hasErrorFor('tags'),
+//               disabled
+//             }}
+//             updateFor={[tags, label, errors]}
+//           />
+//           <AccessPanel
+//             /* disable the password field if we haven't selected an image */
+//             passwordFieldDisabled={
+//               this.props.handleDisablePasswordField(!!selectedImageID) || {
+//                 disabled
+//               }
+//             }
+//             error={hasErrorFor('root_pass')}
+//             updateFor={[password, errors, userSSHKeys, selectedImageID]}
+//             password={password}
+//             handleChange={this.handleTypePassword}
+//             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
+//           />
+//           <AddonsPanel
+//             backups={backups}
+//             accountBackups={accountBackups}
+//             backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
+//             privateIP={privateIP}
+//             changeBackups={this.handleToggleBackups}
+//             changePrivateIP={this.handleTogglePrivateIP}
+//             updateFor={[privateIP, backups, selectedTypeID]}
+//             disabled={disabled}
+//           />
+//         </Grid>
+//         <Grid item className={`${classes.sidebar} mlSidebar`}>
+//           <Sticky topOffset={-24} disableCompensation>
+//             {(props: StickyProps) => {
+//               const displaySections = [];
 
-    return (
-      <React.Fragment>
-        <Grid item className={`${classes.main} mlMain`}>
-          <CreateLinodeDisabled isDisabled={disabled} />
-          {!disabled && notice && (
-            <Notice
-              text={notice.text}
-              error={notice.level === 'error'}
-              warning={notice.level === 'warning'}
-            />
-          )}
-          {generalError && <Notice text={generalError} error={true} />}
-          <CASelectStackScriptPanel
-            error={hasErrorFor('stackscript_id')}
-            header={header}
-            selectedId={selectedStackScriptID}
-            selectedUsername={selectedStackScriptUsername}
-            updateFor={[selectedStackScriptID, errors]}
-            onSelect={this.handleSelectStackScript}
-            publicImages={this.filterPublicImages(images) || []}
-            resetSelectedStackScript={this.resetStackScriptSelection}
-            disabled={disabled}
-            request={request}
-          />
-          {!disabled && userDefinedFields && userDefinedFields.length > 0 && (
-            <UserDefinedFieldsPanel
-              errors={udfErrors}
-              selectedLabel={selectedStackScriptLabel}
-              selectedUsername={selectedStackScriptUsername}
-              handleChange={this.handleChangeUDF}
-              userDefinedFields={userDefinedFields}
-              updateFor={[userDefinedFields, udf_data, errors]}
-              udf_data={udf_data}
-            />
-          )}
-          {!disabled && compatibleImages && compatibleImages.length > 0 ? (
-            <SelectImagePanel
-              images={compatibleImages}
-              handleSelection={this.handleSelectImage}
-              updateFor={[selectedImageID, compatibleImages, errors]}
-              selectedImageID={selectedImageID}
-              error={hasErrorFor('image')}
-              hideMyImages={true}
-            />
-          ) : (
-            <Paper className={classes.emptyImagePanel}>
-              {/* empty state for images */}
-              {hasErrorFor('image') && (
-                <Notice error={true} text={hasErrorFor('image')} />
-              )}
-              <Typography role="header" variant="h2" data-qa-tp="Select Image">
-                Select Image
-              </Typography>
-              <Typography
-                variant="body1"
-                className={classes.emptyImagePanelText}
-                data-qa-no-compatible-images
-              >
-                No Compatible Images Available
-              </Typography>
-            </Paper>
-          )}
-          <SelectRegionPanel
-            error={hasErrorFor('region')}
-            regions={regions}
-            handleSelection={this.handleSelectRegion}
-            selectedID={selectedRegionID}
-            updateFor={[selectedRegionID, errors]}
-            copy="Determine the best location for your Linode."
-            disabled={disabled}
-          />
-          <SelectPlanPanel
-            error={hasErrorFor('type')}
-            types={types}
-            onSelect={this.handleSelectPlan}
-            updateFor={[selectedTypeID, errors]}
-            selectedID={selectedTypeID}
-            disabled={disabled}
-          />
-          <LabelAndTagsPanel
-            labelFieldProps={{
-              label: 'Linode Label',
-              value: label || '',
-              onChange: updateCustomLabel,
-              errorText: hasErrorFor('label'),
-              disabled
-            }}
-            tagsInputProps={{
-              value: tags,
-              onChange: this.handleChangeTags,
-              tagError: hasErrorFor('tags'),
-              disabled
-            }}
-            updateFor={[tags, label, errors]}
-          />
-          <AccessPanel
-            /* disable the password field if we haven't selected an image */
-            passwordFieldDisabled={
-              this.props.handleDisablePasswordField(!!selectedImageID) || {
-                disabled
-              }
-            }
-            error={hasErrorFor('root_pass')}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
-            password={password}
-            handleChange={this.handleTypePassword}
-            users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
-          />
-          <AddonsPanel
-            backups={backups}
-            accountBackups={accountBackups}
-            backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-            privateIP={privateIP}
-            changeBackups={this.handleToggleBackups}
-            changePrivateIP={this.handleTogglePrivateIP}
-            updateFor={[privateIP, backups, selectedTypeID]}
-            disabled={disabled}
-          />
-        </Grid>
-        <Grid item className={`${classes.sidebar} mlSidebar`}>
-          <Sticky topOffset={-24} disableCompensation>
-            {(props: StickyProps) => {
-              const displaySections = [];
+//               if (selectedStackScriptUsername && selectedStackScriptLabel) {
+//                 displaySections.push({
+//                   title:
+//                     selectedStackScriptUsername +
+//                     ' / ' +
+//                     selectedStackScriptLabel
+//                 });
+//               }
 
-              if (selectedStackScriptUsername && selectedStackScriptLabel) {
-                displaySections.push({
-                  title:
-                    selectedStackScriptUsername +
-                    ' / ' +
-                    selectedStackScriptLabel
-                });
-              }
+//               if (imageInfo) {
+//                 displaySections.push(imageInfo);
+//               }
 
-              if (imageInfo) {
-                displaySections.push(imageInfo);
-              }
+//               if (regionInfo) {
+//                 displaySections.push({
+//                   title: regionInfo.title,
+//                   details: regionInfo.details
+//                 });
+//               }
 
-              if (regionInfo) {
-                displaySections.push({
-                  title: regionInfo.title,
-                  details: regionInfo.details
-                });
-              }
+//               if (typeInfo) {
+//                 displaySections.push(typeInfo);
+//               }
 
-              if (typeInfo) {
-                displaySections.push(typeInfo);
-              }
+//               if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                 displaySections.push(
+//                   renderBackupsDisplaySection(
+//                     accountBackups,
+//                     typeInfo.backupsMonthly
+//                   )
+//                 );
+//               }
 
-              if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                displaySections.push(
-                  renderBackupsDisplaySection(
-                    accountBackups,
-                    typeInfo.backupsMonthly
-                  )
-                );
-              }
+//               let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
+//               if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
+//                 calculatedPrice += typeInfo.backupsMonthly;
+//               }
 
-              let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-              if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-                calculatedPrice += typeInfo.backupsMonthly;
-              }
+//               return (
+//                 <CheckoutBar
+//                   heading={`${label || 'Linode'} Summary`}
+//                   calculatedPrice={calculatedPrice}
+//                   isMakingRequest={isMakingRequest}
+//                   disabled={isMakingRequest || disabled}
+//                   onDeploy={this.createFromStackScript}
+//                   displaySections={displaySections}
+//                   {...props}
+//                 />
+//               );
+//             }}
+//           </Sticky>
+//         </Grid>
+//         <StackScriptDrawer />
+//       </React.Fragment>
+//     );
+//   }
+// }
 
-              return (
-                <CheckoutBar
-                  heading={`${label || 'Linode'} Summary`}
-                  calculatedPrice={calculatedPrice}
-                  isMakingRequest={isMakingRequest}
-                  disabled={isMakingRequest || disabled}
-                  onDeploy={this.createFromStackScript}
-                  displaySections={displaySections}
-                  {...props}
-                />
-              );
-            }}
-          </Sticky>
-        </Grid>
-        <StackScriptDrawer />
-      </React.Fragment>
-    );
-  }
-}
+// const styled = withStyles(styles);
 
-const styled = withStyles(styles);
+// const enhanced = compose<CombinedProps, InnerProps>(
+//   styled,
+//   withSnackbar,
+//   userSSHKeyHoc,
+//   withLabelGenerator,
+//   withLinodeActions
+// );
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  withSnackbar,
-  userSSHKeyHoc,
-  withLabelGenerator,
-  withLinodeActions
-);
-
-export default enhanced(FromStackScriptContent) as any;
+// export default enhanced(FromStackScriptContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,613 +1,540 @@
-// import { InjectedNotistackProps, withSnackbar } from 'notistack';
-// import { assocPath, pathOr } from 'ramda';
-// import * as React from 'react';
-// import { Sticky, StickyProps } from 'react-sticky';
-// import { compose } from 'recompose';
-// import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
-// import CheckoutBar from 'src/components/CheckoutBar';
-// import Paper from 'src/components/core/Paper';
-// import {
-//   StyleRulesCallback,
-//   withStyles,
-//   WithStyles
-// } from 'src/components/core/styles';
-// import Typography from 'src/components/core/Typography';
-// import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
-// import Grid from 'src/components/Grid';
-// import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-// import Notice from 'src/components/Notice';
-// import SelectRegionPanel from 'src/components/SelectRegionPanel';
-// import { Tag } from 'src/components/TagsInput';
-// import { resetEventsPolling } from 'src/events';
-// import userSSHKeyHoc from 'src/features/linodes/userSSHKeyHoc';
-// import CASelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel';
-// // import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
-// import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
-// import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-// import {
-//   LinodeActionsProps,
-//   withLinodeActions
-// } from 'src/store/linodes/linode.containers';
-// import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-// import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-// import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-// import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-// import AddonsPanel from '../AddonsPanel';
-// import SelectImagePanel from '../SelectImagePanel';
-// import SelectPlanPanel from '../SelectPlanPanel';
-// import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
-// import { renderBackupsDisplaySection } from './utils';
+import { InjectedNotistackProps, withSnackbar } from 'notistack';
+import { assocPath, pathOr } from 'ramda';
+import * as React from 'react';
+import { Sticky, StickyProps } from 'react-sticky';
+import { compose } from 'recompose';
+import AccessPanel from 'src/components/AccessPanel';
+import CheckoutBar from 'src/components/CheckoutBar';
+import Paper from 'src/components/core/Paper';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+import Grid from 'src/components/Grid';
+import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+import Notice from 'src/components/Notice';
+import SelectRegionPanel from 'src/components/SelectRegionPanel';
+import { Tag } from 'src/components/TagsInput';
+import userSSHKeyHoc, {
+  State as SSHKeys
+} from 'src/features/linodes/userSSHKeyHoc';
+import CASelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel';
+// import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
+import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
+import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
+import {
+  LinodeActionsProps,
+  withLinodeActions
+} from 'src/store/linodes/linode.containers';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import AddonsPanel from '../AddonsPanel';
+import SelectImagePanel from '../SelectImagePanel';
+import SelectPlanPanel from '../SelectPlanPanel';
+import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import { renderBackupsDisplaySection } from './utils';
 
-// import { WithHelperFunctions, WithLinodesImagesTypesAndRegions } from '../types';
+import {
+  StackScriptFormStateHandlers,
+  WithDisplayData,
+  WithLinodesImagesTypesAndRegions
+} from '../types';
 
-// type ClassNames =
-//   | 'root'
-//   | 'main'
-//   | 'sidebar'
-//   | 'emptyImagePanel'
-//   | 'emptyImagePanelText';
+type ClassNames =
+  | 'root'
+  | 'main'
+  | 'sidebar'
+  | 'emptyImagePanel'
+  | 'emptyImagePanelText';
 
-// const styles: StyleRulesCallback<ClassNames> = theme => ({
-//   root: {},
-//   main: {},
-//   sidebar: {
-//     [theme.breakpoints.up('lg')]: {
-//       marginTop: -130
-//     }
-//   },
-//   emptyImagePanel: {
-//     padding: theme.spacing.unit * 3
-//   },
-//   emptyImagePanelText: {
-//     marginTop: theme.spacing.unit,
-//     padding: `${theme.spacing.unit}px 0`
-//   }
-// });
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  main: {},
+  sidebar: {
+    [theme.breakpoints.up('lg')]: {
+      marginTop: -130
+    }
+  },
+  emptyImagePanel: {
+    padding: theme.spacing.unit * 3
+  },
+  emptyImagePanelText: {
+    marginTop: theme.spacing.unit,
+    padding: `${theme.spacing.unit}px 0`
+  }
+});
 
-// interface Notice {
-//   text: string;
-//   level: 'warning' | 'error'; // most likely only going to need these two
-// }
-// interface Props {
-//   notice?: Notice;
-//   history: any;
-//   selectedTabFromQuery?: string;
-//   selectedStackScriptFromQuery?: number;
-//   accountBackups: boolean;
-//   disabled?: boolean;
-//   request: (username: string, params?: any, filter?: any) =>
-//     Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
-//   header: string;
-// }
+interface Notice {
+  text: string;
+  level: 'warning' | 'error'; // most likely only going to need these two
+}
+interface Props {
+  notice?: Notice;
+  history: any;
+  selectedTabFromQuery?: string;
+  selectedStackScriptFromQuery?: number;
+  accountBackups: boolean;
+  disabled?: boolean;
+  request: (
+    username: string,
+    params?: any,
+    filter?: any
+  ) => Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
+  header: string;
+}
 
-// interface SSHKeys {
-//   userSSHKeys: UserSSHKeyObject[];
-// }
+interface State {
+  userDefinedFields: Linode.StackScript.UserDefinedField[];
+  udf_data: any;
+  errors?: Linode.ApiFieldError[];
+  selectedStackScriptLabel: string;
+  selectedStackScriptUsername: string;
+  isMakingRequest: boolean;
+  compatibleImages: Linode.Image[];
+}
 
-// interface State {
-//   userDefinedFields: Linode.StackScript.UserDefinedField[];
-//   udf_data: any;
-//   errors?: Linode.ApiFieldError[];
-//   selectedStackScriptID: number | undefined;
-//   selectedStackScriptLabel: string;
-//   selectedStackScriptUsername: string;
-//   selectedImageID: string | null;
-//   selectedRegionID: string | null;
-//   selectedTypeID: string | null;
-//   backups: boolean;
-//   privateIP: boolean;
-//   label: string | null;
-//   password: string | null;
-//   isMakingRequest: boolean;
-//   compatibleImages: Linode.Image[];
-//   tags: Tag[];
-// }
+const errorResources = {
+  type: 'A plan selection',
+  region: 'A region selection',
+  label: 'A label',
+  root_pass: 'A root password',
+  image: 'image',
+  tags: 'Tags'
+};
 
-// const errorResources = {
-//   type: 'A plan selection',
-//   region: 'A region selection',
-//   label: 'A label',
-//   root_pass: 'A root password',
-//   image: 'image',
-//   tags: 'Tags'
-// };
+type InnerProps = Props & WithLinodesImagesTypesAndRegions;
 
-// type InnerProps = Props & WithHelperFunctions & WithLinodesImagesTypesAndRegions
+type CombinedProps = InnerProps &
+  StackScriptFormStateHandlers &
+  WithDisplayData &
+  LinodeActionsProps &
+  InjectedNotistackProps &
+  LabelProps &
+  SSHKeys &
+  WithStyles<ClassNames>;
 
-// type CombinedProps = InnerProps &
-//   LinodeActionsProps &
-//   InjectedNotistackProps &
-//   LabelProps &
-//   SSHKeys &
-//   WithStyles<ClassNames>;
+export class FromStackScriptContent extends React.Component<
+  CombinedProps,
+  State
+> {
+  state: State = {
+    userDefinedFields: [],
+    udf_data: null,
+    selectedStackScriptLabel: '',
+    selectedStackScriptUsername: this.props.selectedTabFromQuery || '',
+    isMakingRequest: false,
+    compatibleImages: []
+  };
 
-// export class FromStackScriptContent extends React.Component<
-//   CombinedProps,
-//   State
-//   > {
-//   state: State = {
-//     userDefinedFields: [],
-//     udf_data: null,
-//     selectedStackScriptID: this.props.selectedStackScriptFromQuery || undefined,
-//     selectedStackScriptLabel: '',
-//     selectedStackScriptUsername: this.props.selectedTabFromQuery || '',
-//     selectedImageID: null,
-//     selectedRegionID: null,
-//     selectedTypeID: null,
-//     backups: false,
-//     privateIP: false,
-//     label: '',
-//     password: '',
-//     isMakingRequest: false,
-//     compatibleImages: [],
-//     tags: []
-//   };
+  mounted: boolean = false;
 
-//   mounted: boolean = false;
+  handleSelectStackScript = (
+    id: number,
+    label: string,
+    username: string,
+    stackScriptImages: string[],
+    userDefinedFields: Linode.StackScript.UserDefinedField[]
+  ) => {
+    const { imagesData, updateStackScriptID } = this.props;
+    const filteredImages = imagesData.filter(image => {
+      for (const stackScriptImage of stackScriptImages) {
+        if (image.id === stackScriptImage) {
+          return true;
+        }
+      }
+      return false;
+    });
 
-//   handleSelectStackScript = (
-//     id: number,
-//     label: string,
-//     username: string,
-//     stackScriptImages: string[],
-//     userDefinedFields: Linode.StackScript.UserDefinedField[]
-//   ) => {
-//     const { imagesData } = this.props;
-//     const filteredImages = imagesData.filter(image => {
-//       for (const stackScriptImage of stackScriptImages) {
-//         if (image.id === stackScriptImage) {
-//           return true;
-//         }
-//       }
-//       return false;
-//     });
+    const defaultUDFData = {};
+    userDefinedFields.forEach(eachField => {
+      if (!!eachField.default) {
+        defaultUDFData[eachField.name] = eachField.default;
+      }
+    });
+    // first need to make a request to get the stackscript
+    // then update userDefinedFields to the fields returned
+    this.setState(
+      {
+        selectedStackScriptUsername: username,
+        selectedStackScriptLabel: label,
+        compatibleImages: filteredImages,
+        userDefinedFields,
+        udf_data: defaultUDFData
+        // prob gonna need to update UDF here too
+      },
+      () => updateStackScriptID(id)
+    );
+  };
 
-//     const defaultUDFData = {};
-//     userDefinedFields.forEach(eachField => {
-//       if (!!eachField.default) {
-//         defaultUDFData[eachField.name] = eachField.default;
-//       }
-//     });
-//     // first need to make a request to get the stackscript
-//     // then update userDefinedFields to the fields returned
-//     this.setState({
-//       selectedStackScriptID: id,
-//       selectedStackScriptUsername: username,
-//       selectedStackScriptLabel: label,
-//       compatibleImages: filteredImages,
-//       userDefinedFields,
-//       udf_data: defaultUDFData
-//       // prob gonna need to update UDF here too
-//     });
-//   };
+  resetStackScriptSelection = () => {
+    // reset stackscript selection to unselected
+    if (!this.mounted) {
+      return;
+    }
+    this.setState({
+      selectedStackScriptLabel: '',
+      selectedStackScriptUsername: '',
+      udf_data: null,
+      userDefinedFields: [],
+      compatibleImages: []
+    });
+  };
 
-//   resetStackScriptSelection = () => {
-//     // reset stackscript selection to unselected
-//     if (!this.mounted) {
-//       return;
-//     }
-//     this.setState({
-//       selectedStackScriptID: undefined,
-//       selectedStackScriptLabel: '',
-//       selectedStackScriptUsername: '',
-//       udf_data: null,
-//       userDefinedFields: [],
-//       compatibleImages: [],
-//       selectedImageID: null // stackscripts don't support all images, so we need to reset it
-//     });
-//   };
+  handleChangeUDF = (key: string, value: string) => {
+    // either overwrite or create new selection
+    const newUDFData = assocPath([key], value, this.state.udf_data);
 
-//   handleChangeUDF = (key: string, value: string) => {
-//     // either overwrite or create new selection
-//     const newUDFData = assocPath([key], value, this.state.udf_data);
+    this.setState({
+      udf_data: { ...this.state.udf_data, ...newUDFData }
+    });
+  };
 
-//     this.setState({
-//       udf_data: { ...this.state.udf_data, ...newUDFData }
-//     });
-//   };
+  createFromStackScript = () => {
+    if (!this.props.selectedStackScriptID) {
+      this.setState(
+        {
+          errors: [
+            { field: 'stackscript_id', reason: 'You must select a StackScript' }
+          ]
+        },
+        () => {
+          scrollErrorIntoView();
+        }
+      );
+      return;
+    }
+    this.createLinode();
+  };
 
-//   handleSelectImage = (id: string) => {
-//     this.setState({ selectedImageID: id });
-//   };
+  createLinode = () => {
+    const {
+      backupsEnabled,
+      password,
+      userSSHKeys,
+      handleSubmitForm,
+      selectedImageID,
+      selectedRegionID,
+      selectedStackScriptID,
+      selectedTypeID,
+      tags
+    } = this.props;
+    const { udf_data } = this.state;
 
-//   handleSelectRegion = (id: string) => {
-//     this.setState({ selectedRegionID: id });
-//   };
+    this.setState({ isMakingRequest: true });
 
-//   handleSelectPlan = (id: string) => {
-//     this.setState({ selectedTypeID: id });
-//   };
+    const label = this.label();
 
-//   handleChangeTags = (selected: Tag[]) => {
-//     this.setState({ tags: selected });
-//   };
+    handleSubmitForm('create', {
+      region: selectedRegionID,
+      type: selectedTypeID,
+      stackscript_id: selectedStackScriptID,
+      stackscript_data: udf_data,
+      label /* optional */,
+      root_pass: password /* required if image ID is provided */,
+      image: selectedImageID /* optional */,
+      backups_enabled: backupsEnabled /* optional */,
+      booted: true,
+      authorized_users: userSSHKeys
+        .filter(u => u.selected)
+        .map(u => u.username),
+      tags: tags ? tags.map((item: Tag) => item.value) : []
+    });
+  };
 
-//   handleTypePassword = (value: string) => {
-//     this.setState({ password: value });
-//   };
+  componentDidMount() {
+    this.mounted = true;
+  }
 
-//   handleToggleBackups = () => {
-//     this.setState({ backups: !this.state.backups });
-//   };
+  componentWillUnmount() {
+    this.mounted = false;
+  }
 
-//   handleTogglePrivateIP = () => {
-//     this.setState({ privateIP: !this.state.privateIP });
-//   };
+  filterPublicImages = (images: Linode.Image[]) => {
+    return images.filter((image: Linode.Image) => image.is_public);
+  };
 
-//   createFromStackScript = () => {
-//     if (!this.state.selectedStackScriptID) {
-//       this.setState(
-//         {
-//           errors: [
-//             { field: 'stackscript_id', reason: 'You must select a StackScript' }
-//           ]
-//         },
-//         () => {
-//           scrollErrorIntoView();
-//         }
-//       );
-//       return;
-//     }
-//     this.createLinode();
-//   };
+  label = () => {
+    const { selectedStackScriptLabel } = this.state;
 
-//   createLinode = () => {
-//     const {
-//       history,
-//       userSSHKeys,
-//       linodeActions: { createLinode }
-//     } = this.props;
-//     const {
-//       selectedImageID,
-//       selectedRegionID,
-//       selectedTypeID,
-//       selectedStackScriptID,
-//       udf_data,
-//       password,
-//       backups,
-//       privateIP,
-//       tags
-//     } = this.state;
+    const {
+      getLabel,
+      imagesData,
+      selectedImageID,
+      selectedRegionID
+    } = this.props;
 
-//     this.setState({ isMakingRequest: true });
+    const selectedImage = imagesData.find(img => img.id === selectedImageID);
 
-//     const label = this.label();
+    const image = selectedImage && selectedImage.vendor;
 
-//     createLinode({
-//       region: selectedRegionID,
-//       type: selectedTypeID,
-//       stackscript_id: selectedStackScriptID,
-//       stackscript_data: udf_data,
-//       label: label ? label : null /* optional */,
-//       root_pass: password /* required if image ID is provided */,
-//       image: selectedImageID /* optional */,
-//       backups_enabled: backups /* optional */,
-//       booted: true,
-//       authorized_users: userSSHKeys
-//         .filter(u => u.selected)
-//         .map(u => u.username),
-//       tags: tags.map((item: Tag) => item.value)
-//     })
-//       .then(linode => {
-//         if (privateIP) {
-//           allocatePrivateIP(linode.id);
-//         }
+    return getLabel(selectedStackScriptLabel, image, selectedRegionID);
+  };
 
-//         this.props.enqueueSnackbar(`Your Linode ${label} is being created.`, {
-//           variant: 'success'
-//         });
+  render() {
+    const {
+      errors,
+      userDefinedFields,
+      udf_data,
+      isMakingRequest,
+      compatibleImages,
+      selectedStackScriptLabel,
+      selectedStackScriptUsername
+    } = this.state;
 
-//         resetEventsPolling();
-//         history.push('/linodes');
-//       })
-//       .catch(error => {
-//         if (!this.mounted) {
-//           return;
-//         }
-//         this.setState(
-//           () => ({
-//             errors: getAPIErrorOrDefault(error)
-//           }),
-//           () => {
-//             scrollErrorIntoView();
-//           }
-//         );
-//       })
-//       .finally(() => {
-//         if (!this.mounted) {
-//           return;
-//         }
-//         // regardless of whether request failed or not, change state and enable the submit btn
-//         this.setState({ isMakingRequest: false });
-//       });
-//   };
+    const {
+      accountBackups,
+      notice,
+      backupsMonthlyPrice,
+      regionsData,
+      typesData,
+      classes,
+      imageDisplayInfo,
+      regionDisplayInfo,
+      selectedImageID,
+      selectedRegionID,
+      selectedStackScriptID,
+      selectedTypeID,
+      typeDisplayInfo,
+      privateIPEnabled,
+      tags,
+      backupsEnabled,
+      password,
+      imagesData,
+      userSSHKeys,
+      updateCustomLabel,
+      disabled,
+      request,
+      header,
+      toggleBackupsEnabled,
+      togglePrivateIPEnabled,
+      updateImageID,
+      updatePassword,
+      updateRegionID,
+      updateTags,
+      updateTypeID
+    } = this.props;
 
-//   componentDidMount() {
-//     this.mounted = true;
-//   }
+    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+    const generalError = hasErrorFor('none');
 
-//   componentWillUnmount() {
-//     this.mounted = false;
-//   }
+    const hasBackups = Boolean(backupsEnabled || accountBackups);
 
-//   filterPublicImages = (images: Linode.Image[]) => {
-//     return images.filter((image: Linode.Image) => image.is_public);
-//   };
+    const label = this.label();
 
-//   label = () => {
-//     const {
-//       selectedStackScriptLabel,
-//       selectedImageID,
-//       selectedRegionID
-//     } = this.state;
-//     const { getLabel, imagesData } = this.props;
+    /*
+     * errors with UDFs have dynamic keys
+     * for exmaple, if there are UDFs that aren't filled out, you can can
+     * errors that look something like this
+     * { field: 'wordpress_pass', reason: 'you must fill out a WP password' }
+     * Because of this, we need to both make each error doesn't match any
+     * that are in our errorResources map and that it has a 'field' key in the first
+     * place. Then, we can confirm we are indeed looking at a UDF error
+     */
+    const udfErrors = errors
+      ? errors.filter(error => {
+          // ensure the error isn't a root_pass, image, region, type, label
+          const isNotUDFError = Object.keys(errorResources).some(errorKey => {
+            return errorKey === error.field;
+          });
+          // if the 'field' prop exists and isn't any other error
+          return !!error.field && !isNotUDFError;
+        })
+      : undefined;
 
-//     const selectedImage = imagesData.find(img => img.id === selectedImageID);
+    return (
+      <React.Fragment>
+        <Grid item className={`${classes.main} mlMain`}>
+          <CreateLinodeDisabled isDisabled={disabled} />
+          {!disabled && notice && (
+            <Notice
+              text={notice.text}
+              error={notice.level === 'error'}
+              warning={notice.level === 'warning'}
+            />
+          )}
+          {generalError && <Notice text={generalError} error={true} />}
+          <CASelectStackScriptPanel
+            error={hasErrorFor('stackscript_id')}
+            header={header}
+            selectedId={selectedStackScriptID}
+            selectedUsername={selectedStackScriptUsername}
+            updateFor={[selectedStackScriptID, errors]}
+            onSelect={this.handleSelectStackScript}
+            publicImages={this.filterPublicImages(imagesData) || []}
+            resetSelectedStackScript={this.resetStackScriptSelection}
+            disabled={disabled}
+            request={request}
+          />
+          {!disabled && userDefinedFields && userDefinedFields.length > 0 && (
+            <UserDefinedFieldsPanel
+              errors={udfErrors}
+              selectedLabel={selectedStackScriptLabel}
+              selectedUsername={selectedStackScriptUsername}
+              handleChange={this.handleChangeUDF}
+              userDefinedFields={userDefinedFields}
+              updateFor={[userDefinedFields, udf_data, errors]}
+              udf_data={udf_data}
+            />
+          )}
+          {!disabled && compatibleImages && compatibleImages.length > 0 ? (
+            <SelectImagePanel
+              images={compatibleImages}
+              handleSelection={updateImageID}
+              updateFor={[selectedImageID, compatibleImages, errors]}
+              selectedImageID={selectedImageID}
+              error={hasErrorFor('image')}
+              hideMyImages={true}
+            />
+          ) : (
+            <Paper className={classes.emptyImagePanel}>
+              {/* empty state for images */}
+              {hasErrorFor('image') && (
+                <Notice error={true} text={hasErrorFor('image')} />
+              )}
+              <Typography role="header" variant="h2" data-qa-tp="Select Image">
+                Select Image
+              </Typography>
+              <Typography
+                variant="body1"
+                className={classes.emptyImagePanelText}
+                data-qa-no-compatible-images
+              >
+                No Compatible Images Available
+              </Typography>
+            </Paper>
+          )}
+          <SelectRegionPanel
+            error={hasErrorFor('region')}
+            regions={regionsData}
+            handleSelection={updateRegionID}
+            selectedID={selectedRegionID}
+            updateFor={[selectedRegionID, errors]}
+            copy="Determine the best location for your Linode."
+            disabled={disabled}
+          />
+          <SelectPlanPanel
+            error={hasErrorFor('type')}
+            types={typesData}
+            onSelect={updateTypeID}
+            updateFor={[selectedTypeID, errors]}
+            selectedID={selectedTypeID}
+            disabled={disabled}
+          />
+          <LabelAndTagsPanel
+            labelFieldProps={{
+              label: 'Linode Label',
+              value: label || '',
+              onChange: updateCustomLabel,
+              errorText: hasErrorFor('label'),
+              disabled
+            }}
+            tagsInputProps={{
+              value: tags || [],
+              onChange: updateTags,
+              tagError: hasErrorFor('tags'),
+              disabled
+            }}
+            updateFor={[tags, label, errors]}
+          />
+          <AccessPanel
+            /* disable the password field if we haven't selected an image */
+            disabled={!this.props.selectedImageID}
+            disabledReason={
+              !this.props.selectedImageID
+                ? 'You must select an image to set a root password'
+                : ''
+            }
+            error={hasErrorFor('root_pass')}
+            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            password={password}
+            handleChange={updatePassword}
+            users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
+          />
+          <AddonsPanel
+            backups={backupsEnabled}
+            accountBackups={accountBackups}
+            backupsMonthly={backupsMonthlyPrice}
+            privateIP={privateIPEnabled}
+            changeBackups={toggleBackupsEnabled}
+            changePrivateIP={togglePrivateIPEnabled}
+            updateFor={[privateIPEnabled, backupsEnabled, selectedTypeID]}
+            disabled={disabled}
+          />
+        </Grid>
+        <Grid item className={`${classes.sidebar} mlSidebar`}>
+          <Sticky topOffset={-24} disableCompensation>
+            {(props: StickyProps) => {
+              const displaySections = [];
 
-//     const image = selectedImage && selectedImage.vendor;
+              if (selectedStackScriptUsername && selectedStackScriptLabel) {
+                displaySections.push({
+                  title:
+                    selectedStackScriptUsername +
+                    ' / ' +
+                    selectedStackScriptLabel
+                });
+              }
 
-//     return getLabel(selectedStackScriptLabel, image, selectedRegionID);
-//   };
+              if (imageDisplayInfo) {
+                displaySections.push(imageDisplayInfo);
+              }
 
-//   render() {
-//     const {
-//       errors,
-//       userDefinedFields,
-//       udf_data,
-//       selectedImageID,
-//       selectedRegionID,
-//       selectedStackScriptID,
-//       selectedTypeID,
-//       backups,
-//       privateIP,
-//       tags,
-//       password,
-//       isMakingRequest,
-//       compatibleImages,
-//       selectedStackScriptLabel,
-//       selectedStackScriptUsername
-//     } = this.state;
+              if (regionDisplayInfo) {
+                displaySections.push({
+                  title: regionDisplayInfo.title,
+                  details: regionDisplayInfo.details
+                });
+              }
 
-//     const {
-//       accountBackups,
-//       notice,
-//       getBackupsMonthlyPrice,
-//       regionsData,
-//       typesData,
-//       classes,
-//       getRegionInfo,
-//       getTypeInfo,
-//       imagesData,
-//       userSSHKeys,
-//       updateCustomLabel,
-//       disabled,
-//       request,
-//       header
-//     } = this.props;
+              if (typeDisplayInfo) {
+                displaySections.push(typeDisplayInfo);
+              }
 
-//     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-//     const generalError = hasErrorFor('none');
+              if (hasBackups && typeDisplayInfo && backupsMonthlyPrice) {
+                displaySections.push(
+                  renderBackupsDisplaySection(
+                    accountBackups,
+                    backupsMonthlyPrice
+                  )
+                );
+              }
 
-//     const hasBackups = Boolean(backups || accountBackups);
+              let calculatedPrice = pathOr(0, ['monthly'], typeDisplayInfo);
+              if (hasBackups && typeDisplayInfo && backupsMonthlyPrice) {
+                calculatedPrice += backupsMonthlyPrice;
+              }
 
-//     const label = this.label();
+              return (
+                <CheckoutBar
+                  heading={`${label || 'Linode'} Summary`}
+                  calculatedPrice={calculatedPrice}
+                  isMakingRequest={isMakingRequest}
+                  disabled={isMakingRequest || disabled}
+                  onDeploy={this.createFromStackScript}
+                  displaySections={displaySections}
+                  {...props}
+                />
+              );
+            }}
+          </Sticky>
+        </Grid>
+        <StackScriptDrawer />
+      </React.Fragment>
+    );
+  }
+}
 
-//     /*
-//      * errors with UDFs have dynamic keys
-//      * for exmaple, if there are UDFs that aren't filled out, you can can
-//      * errors that look something like this
-//      * { field: 'wordpress_pass', reason: 'you must fill out a WP password' }
-//      * Because of this, we need to both make each error doesn't match any
-//      * that are in our errorResources map and that it has a 'field' key in the first
-//      * place. Then, we can confirm we are indeed looking at a UDF error
-//      */
-//     const udfErrors = errors
-//       ? errors.filter(error => {
-//         // ensure the error isn't a root_pass, image, region, type, label
-//         const isNotUDFError = Object.keys(errorResources).some(errorKey => {
-//           return errorKey === error.field;
-//         });
-//         // if the 'field' prop exists and isn't any other error
-//         return !!error.field && !isNotUDFError;
-//       })
-//       : undefined;
+const styled = withStyles(styles);
 
-//     const regionInfo = getRegionInfo(selectedRegionID);
-//     const typeInfo = getTypeInfo(selectedTypeID);
-//     const imageInfo = this.props.getImageInfo(
-//       imagesData.find(image => image.id === selectedImageID)
-//     );
+const enhanced = compose<CombinedProps, InnerProps>(
+  styled,
+  withSnackbar,
+  userSSHKeyHoc,
+  withLabelGenerator,
+  withLinodeActions
+);
 
-//     return (
-//       <React.Fragment>
-//         <Grid item className={`${classes.main} mlMain`}>
-//           <CreateLinodeDisabled isDisabled={disabled} />
-//           {!disabled && notice && (
-//             <Notice
-//               text={notice.text}
-//               error={notice.level === 'error'}
-//               warning={notice.level === 'warning'}
-//             />
-//           )}
-//           {generalError && <Notice text={generalError} error={true} />}
-//           <CASelectStackScriptPanel
-//             error={hasErrorFor('stackscript_id')}
-//             header={header}
-//             selectedId={selectedStackScriptID}
-//             selectedUsername={selectedStackScriptUsername}
-//             updateFor={[selectedStackScriptID, errors]}
-//             onSelect={this.handleSelectStackScript}
-//             publicImages={this.filterPublicImages(imagesData) || []}
-//             resetSelectedStackScript={this.resetStackScriptSelection}
-//             disabled={disabled}
-//             request={request}
-//           />
-//           {!disabled && userDefinedFields && userDefinedFields.length > 0 && (
-//             <UserDefinedFieldsPanel
-//               errors={udfErrors}
-//               selectedLabel={selectedStackScriptLabel}
-//               selectedUsername={selectedStackScriptUsername}
-//               handleChange={this.handleChangeUDF}
-//               userDefinedFields={userDefinedFields}
-//               updateFor={[userDefinedFields, udf_data, errors]}
-//               udf_data={udf_data}
-//             />
-//           )}
-//           {!disabled && compatibleImages && compatibleImages.length > 0 ? (
-//             <SelectImagePanel
-//               images={compatibleImages}
-//               handleSelection={this.handleSelectImage}
-//               updateFor={[selectedImageID, compatibleImages, errors]}
-//               selectedImageID={selectedImageID}
-//               error={hasErrorFor('image')}
-//               hideMyImages={true}
-//             />
-//           ) : (
-//               <Paper className={classes.emptyImagePanel}>
-//                 {/* empty state for images */}
-//                 {hasErrorFor('image') && (
-//                   <Notice error={true} text={hasErrorFor('image')} />
-//                 )}
-//                 <Typography role="header" variant="h2" data-qa-tp="Select Image">
-//                   Select Image
-//               </Typography>
-//                 <Typography
-//                   variant="body1"
-//                   className={classes.emptyImagePanelText}
-//                   data-qa-no-compatible-images
-//                 >
-//                   No Compatible Images Available
-//               </Typography>
-//               </Paper>
-//             )}
-//           <SelectRegionPanel
-//             error={hasErrorFor('region')}
-//             regions={regionsData}
-//             handleSelection={this.handleSelectRegion}
-//             selectedID={selectedRegionID}
-//             updateFor={[selectedRegionID, errors]}
-//             copy="Determine the best location for your Linode."
-//             disabled={disabled}
-//           />
-//           <SelectPlanPanel
-//             error={hasErrorFor('type')}
-//             types={typesData}
-//             onSelect={this.handleSelectPlan}
-//             updateFor={[selectedTypeID, errors]}
-//             selectedID={selectedTypeID}
-//             disabled={disabled}
-//           />
-//           <LabelAndTagsPanel
-//             labelFieldProps={{
-//               label: 'Linode Label',
-//               value: label || '',
-//               onChange: updateCustomLabel,
-//               errorText: hasErrorFor('label'),
-//               disabled
-//             }}
-//             tagsInputProps={{
-//               value: tags,
-//               onChange: this.handleChangeTags,
-//               tagError: hasErrorFor('tags'),
-//               disabled
-//             }}
-//             updateFor={[tags, label, errors]}
-//           />
-//           <AccessPanel
-//             /* disable the password field if we haven't selected an image */
-//             passwordFieldDisabled={
-//               this.props.handleDisablePasswordField(!!selectedImageID) || {
-//                 disabled
-//               }
-//             }
-//             error={hasErrorFor('root_pass')}
-//             updateFor={[password, errors, userSSHKeys, selectedImageID]}
-//             password={password}
-//             handleChange={this.handleTypePassword}
-//             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
-//           />
-//           <AddonsPanel
-//             backups={backups}
-//             accountBackups={accountBackups}
-//             backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
-//             privateIP={privateIP}
-//             changeBackups={this.handleToggleBackups}
-//             changePrivateIP={this.handleTogglePrivateIP}
-//             updateFor={[privateIP, backups, selectedTypeID]}
-//             disabled={disabled}
-//           />
-//         </Grid>
-//         <Grid item className={`${classes.sidebar} mlSidebar`}>
-//           <Sticky topOffset={-24} disableCompensation>
-//             {(props: StickyProps) => {
-//               const displaySections = [];
-
-//               if (selectedStackScriptUsername && selectedStackScriptLabel) {
-//                 displaySections.push({
-//                   title:
-//                     selectedStackScriptUsername +
-//                     ' / ' +
-//                     selectedStackScriptLabel
-//                 });
-//               }
-
-//               if (imageInfo) {
-//                 displaySections.push(imageInfo);
-//               }
-
-//               if (regionInfo) {
-//                 displaySections.push({
-//                   title: regionInfo.title,
-//                   details: regionInfo.details
-//                 });
-//               }
-
-//               if (typeInfo) {
-//                 displaySections.push(typeInfo);
-//               }
-
-//               if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-//                 displaySections.push(
-//                   renderBackupsDisplaySection(
-//                     accountBackups,
-//                     typeInfo.backupsMonthly
-//                   )
-//                 );
-//               }
-
-//               let calculatedPrice = pathOr(0, ['monthly'], typeInfo);
-//               if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
-//                 calculatedPrice += typeInfo.backupsMonthly;
-//               }
-
-//               return (
-//                 <CheckoutBar
-//                   heading={`${label || 'Linode'} Summary`}
-//                   calculatedPrice={calculatedPrice}
-//                   isMakingRequest={isMakingRequest}
-//                   disabled={isMakingRequest || disabled}
-//                   onDeploy={this.createFromStackScript}
-//                   displaySections={displaySections}
-//                   {...props}
-//                 />
-//               );
-//             }}
-//           </Sticky>
-//         </Grid>
-//         <StackScriptDrawer />
-//       </React.Fragment>
-//     );
-//   }
-// }
-
-// const styled = withStyles(styles);
-
-// const enhanced = compose<CombinedProps, InnerProps>(
-//   styled,
-//   withSnackbar,
-//   userSSHKeyHoc,
-//   withLabelGenerator,
-//   withLinodeActions
-// );
-
-// export default enhanced(FromStackScriptContent);
+export default enhanced(FromStackScriptContent);

--- a/src/features/linodes/LinodesCreate/index.ts
+++ b/src/features/linodes/LinodesCreate/index.ts
@@ -1,2 +1,2 @@
-import LinodesCreate from './LinodesCreate';
+import LinodesCreate from './LinodeCreateContainer';
 export default LinodesCreate;

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -54,7 +54,7 @@ export interface ReduxStateProps {
 }
 
 export type HandleSubmit = (
-  type: 'create' | 'clone',
+  type: 'create' | 'clone' | 'createFromStackScript',
   payload: CreateLinodeRequest,
   linodeID?: number
 ) => void;
@@ -105,8 +105,19 @@ export interface CloneFormStateHandlers extends BaseFormStateAndHandlers {
  */
 export interface StackScriptFormStateHandlers extends BaseFormStateAndHandlers {
   selectedStackScriptID?: number;
-  updateStackScriptID: (id: number) => void;
-  selectedUDFs?: any[];
+  selectedStackScriptUsername?: string;
+  selectedStackScriptLabel?: string;
+  availableUserDefinedFields?: Linode.StackScript.UserDefinedField[];
+  availableStackScriptImages?: Linode.Image[];
+  updateStackScript: (
+    id: number,
+    label: string,
+    username: string,
+    userDefinedFields: Linode.StackScript.UserDefinedField[],
+    availableImages: Linode.Image[],
+    defaultData?: any
+  ) => void;
+  selectedUDFs?: any;
   handleSelectUDFs: (stackScripts: any[]) => void;
 }
 

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -1,0 +1,127 @@
+import { ExtendedRegion } from 'src/components/SelectRegionPanel';
+import { Tag } from 'src/components/TagsInput';
+import { CreateLinodeRequest } from 'src/services/linodes';
+import { ExtendedType } from './SelectPlanPanel';
+
+export interface ExtendedLinode extends Linode.Linode {
+  heading: string;
+  subHeadings: string[];
+}
+
+export type TypeInfo =
+  | {
+      title: string;
+      details: string;
+      monthly: number;
+      backupsMonthly: number | null;
+    }
+  | undefined;
+
+export type Info = { title: string; details?: string } | undefined;
+
+export interface WithDisplayData {
+  typeDisplayInfo?: TypeInfo;
+  regionDisplayInfo?: Info;
+  imageDisplayInfo?: Info;
+  backupsMonthlyPrice?: number | null;
+}
+
+interface WithImagesProps {
+  imagesData: Linode.Image[];
+  imagesLoading: boolean;
+  imagesError?: string;
+}
+
+interface WithLinodesProps {
+  linodesData: Linode.Linode[];
+  linodesLoading: boolean;
+  linodesError?: Linode.ApiFieldError[];
+}
+
+interface WithRegions {
+  regionsData: ExtendedRegion[];
+  regionsLoading: boolean;
+  regionsError: Linode.ApiFieldError[];
+}
+
+interface WithTypesProps {
+  typesData: ExtendedType[];
+}
+
+export interface ReduxStateProps {
+  accountBackupsEnabled: boolean;
+  userCannotCreateLinode: boolean;
+}
+
+// selectedDiskSize?: number;
+// updateDiskSize: (id: number) => void;
+
+export type HandleSubmit = (
+  type: 'create' | 'clone',
+  payload: CreateLinodeRequest,
+  linodeID?: number
+) => void;
+
+/**
+ * minimum number of state and handlers needed for
+ * the _create from image_ flow to function
+ */
+export interface BaseFormStateAndHandlers {
+  errors?: Linode.ApiFieldError[];
+  formIsSubmitting: boolean;
+  handleSubmitForm: HandleSubmit;
+  selectedImageID?: string;
+  updateImageID: (id: string) => void;
+  selectedRegionID?: string;
+  updateRegionID: (id: string) => void;
+  selectedTypeID?: string;
+  updateTypeID: (id: string) => void;
+  label: string;
+  updateLabel: (
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => void;
+  password: string;
+  updatePassword: (password: string) => void;
+  backupsEnabled: boolean;
+  toggleBackupsEnabled: () => void;
+  privateIPEnabled: boolean;
+  togglePrivateIPEnabled: () => void;
+  tags?: Tag[];
+  updateTags: (tags: Tag[]) => void;
+}
+
+/**
+ * additional form fields needed when creating a Linode from a Linode
+ * AKA cloning a Linode
+ */
+export interface CloneFormStateHandlers extends BaseFormStateAndHandlers {
+  selectedLinodeID?: number;
+  updateLinodeID: (id: number) => void;
+}
+
+/**
+ * additional form fields needed when creating a Linode from a StackScript
+ */
+export interface StackScriptFormStateHandlers extends BaseFormStateAndHandlers {
+  selectedStackScriptID?: number;
+  updateStackScriptID: (id: number) => void;
+  selectedUDFs?: any[];
+  handleSelectUDFs: (stackScripts: any[]) => void;
+}
+
+export type AllFormStateAndHandlers = BaseFormStateAndHandlers &
+  CloneFormStateHandlers &
+  StackScriptFormStateHandlers;
+
+export type WithLinodesImagesTypesAndRegions = WithImagesProps &
+  WithLinodesProps &
+  WithRegions &
+  WithTypesProps &
+  ReduxStateProps;
+
+export type WithImagesRegionsTypesAndAccountState = WithImagesProps &
+  WithRegions &
+  WithTypesProps &
+  ReduxStateProps;

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -53,9 +53,6 @@ export interface ReduxStateProps {
   userCannotCreateLinode: boolean;
 }
 
-// selectedDiskSize?: number;
-// updateDiskSize: (id: number) => void;
-
 export type HandleSubmit = (
   type: 'create' | 'clone',
   payload: CreateLinodeRequest,
@@ -97,8 +94,10 @@ export interface BaseFormStateAndHandlers {
  * AKA cloning a Linode
  */
 export interface CloneFormStateHandlers extends BaseFormStateAndHandlers {
+  selectedDiskSize?: number;
+  updateDiskSize: (id: number) => void;
   selectedLinodeID?: number;
-  updateLinodeID: (id: number) => void;
+  updateLinodeID: (id: number, diskSize?: number) => void;
 }
 
 /**

--- a/src/features/linodes/LinodesCreate/util.ts
+++ b/src/features/linodes/LinodesCreate/util.ts
@@ -1,1 +1,0 @@
-export type Info = { title: string; details?: string } | undefined;

--- a/src/features/linodes/LinodesCreate/utilites.ts
+++ b/src/features/linodes/LinodesCreate/utilites.ts
@@ -1,0 +1,34 @@
+import { compose, find, lensPath, prop, propEq, set } from 'ramda';
+import { displayType } from 'src/features/linodes/presentation';
+import { ExtendedType } from './SelectPlanPanel';
+import { ExtendedLinode } from './types';
+
+export const extendLinodes = (
+  linodes: Linode.Linode[],
+  imagesData?: Linode.Image[],
+  typesData?: ExtendedType[]
+): ExtendedLinode[] => {
+  const images = imagesData || [];
+  const types = typesData || [];
+  return linodes.map(
+    linode =>
+      compose<Linode.Linode, Partial<ExtendedLinode>, Partial<ExtendedLinode>>(
+        set(lensPath(['heading']), linode.label),
+        set(
+          lensPath(['subHeadings']),
+          formatLinodeSubheading(
+            displayType(linode.type, types),
+            compose<Linode.Image[], Linode.Image, string>(
+              prop('label'),
+              find(propEq('id', linode.image))
+            )(images)
+          )
+        )
+      )(linode) as ExtendedLinode
+  );
+};
+
+const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
+  const subheading = imageInfo ? `${typeInfo}, ${imageInfo}` : `${typeInfo}`;
+  return [subheading];
+};

--- a/src/features/linodes/index.tsx
+++ b/src/features/linodes/index.tsx
@@ -13,7 +13,7 @@ const LinodesLanding = DefaultLoader({
 });
 
 const LinodesCreate = DefaultLoader({
-  loader: () => import('./LinodesCreate/CALinodeCreate')
+  loader: () => import('./LinodesCreate/LinodeCreateContainer')
 });
 
 const LinodesDetail = DefaultLoader({

--- a/src/services/linodes/linodes.ts
+++ b/src/services/linodes/linodes.ts
@@ -12,18 +12,18 @@ type Page<T> = Linode.ResourcePage<T>;
 type Linode = Linode.Linode;
 
 export interface CreateLinodeRequest {
-  type: string | null;
-  region: string | null;
+  type?: string;
+  region?: string;
   stackscript_id?: number;
   backup_id?: number;
   swap_size?: number;
-  image?: string | null;
-  root_pass?: string | null;
+  image?: string;
+  root_pass?: string;
   authorized_keys?: string[];
   backups_enabled?: boolean;
   stackscript_data?: any;
   booted?: boolean;
-  label: string | null;
+  label?: string;
   tags?: string[];
   private_ip?: boolean;
   authorized_users?: string[];


### PR DESCRIPTION
## Description

Lift all helper functions, form state, and form state updaters to a container component.

Make all child components as dumb as possible

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The only tab that is currently working is the _create from image_ flow

### To Do
- [ ] Fix all tests
- [ ] Fix the custom label generator
- [ ] handle error states for if regions, linodes, or images failed to load
- [ ] Move SSHKeys HOC to the container
- [ ] Move Checkout bar to the conatainer
- [ ] Reset form state on tab change
- [ ] Pass down UDF errors to UDF form and map the errors to the field

### Bugs
-------
1. Click on My Images > My StackScripts
2. Click on One-Click
3. Crash - `cannot read property 'render' of undefined`
-------