### PR TITLE
Update FakeSpec.ts

### DIFF
--- a/src/features/OneClickApps/FakeSpec.ts
+++ b/src/features/OneClickApps/FakeSpec.ts
@@ -15,16 +15,13 @@ export interface Doc {
 export const oneClickApps: OCA[] = [
   {
     name: 'Ark',
-    description: `Ark: Survival Evolved is a multiplayer action-survival game released in 2017.
-      You are placed on a series of fictional islands inhabited by dinosaurs and
-      other prehistoric animals. In Ark, the main objective is to survive. Ark is
-      an ongoing battle where animals and other players have the ability to destroy you.
+    description: `In Ark: Survival Evolved, you are placed on a series of fictional islands inhabited by dinosaurs and
+      other prehistoric animals. Ark is an ongoing battle where animals and other players have the ability to destroy you.
       You must build structures, farm resources, breed dinosaurs, and even set up
       trading hubs with neighboring tribes. Hosting an Ark server gives you control
       of the entire game. You can define the leveling speed, the amount of players,
       and the types of weapons available.`,
-    summary: `Multiplayer action-survival game where you are placed on a series of fictional
-      islands inhabited by prehistoric creatures. You have only one objective: survive.`,
+    summary: `Multiplayer action-survival game. You have only one objective: survive.`,
     related_guides: [
       {
         title: 'Deploy an ARK: Survival Evolved Server with One-Click Apps',
@@ -38,7 +35,7 @@ export const oneClickApps: OCA[] = [
   {
     name: 'CS:GO',
     description: `Fast-paced, competitive FPS. Partner with your team to compete the objective at hand, or take matters into your own hands and go solo.`,
-    summary: `Global Offensive is a fast-paced first person shooter. In CS:GO there are two teams: Terrorists and Counter-Terrorists.
+    summary: `In CS:GO there are two teams: Terrorists and Counter-Terrorists.
       The teams compete against each other to complete objectives or to eliminate the opposing team.
       A competitive match requires two teams of five players, but hosting your own server allows you control over team size and server location,
       so you and your friends can play with low latency. Up to 64 players can be hosted on a single server.`,
@@ -91,8 +88,8 @@ export const oneClickApps: OCA[] = [
       interactive community websites with forums, user blogs, and private messaging.
       Drupal also has support for personal publishing projects and can power podcasts,
       blogs, and knowledge-based systems, all within a single, unified platform.`,
-    summary: `Powerful content management system built on PHP and supported by a database.
-      engine. Drupal sites can be rich and interactive, and the Drupal API eases development.`,
+    summary: `Powerful content management system built on PHP and supported by a database
+      engine.`,
     related_guides: [
       {
         title: 'Deploy Drupal with One-Click Apps',
@@ -118,8 +115,7 @@ export const oneClickApps: OCA[] = [
       PHP application code to your new app or use a PHP framework to write
       a new application on the Linode.`,
     summary: `Build PHP-based applications with the LAMP software stack: Linux, Apache,
-      MySQL, and PHP. The LAMP stack is the foundation for popular frameworks
-      like WordPress and Drupal.`,
+      MySQL, and PHP.`,
     related_guides: [
       {
         title: 'Deploy a LAMP Stack with One-Click Apps',
@@ -132,7 +128,7 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'Rust',
-    description: `In Rust, you play as a survivor and must work with or against other players
+    description: `In Rust, you must work with or against other players
       to ensure your own survival. Players are able to steal, lie, cheat, or
       trick each other. Build a shelter, hunt animals for food, craft weapons and
       armor, and much more. Hosting your own Rust server allows you to customize
@@ -151,9 +147,7 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'Terraria',
-    description: `Terraria is a two-dimensional sandbox game in which players explore the
-      world, collect resources, build structures, and battle enemies in
-      procedurally generated environments. In Terraria a player begins by digging
+    description: `Terraria generates unique environments where a player begins by digging
       for ore, and the further they dig the more adventure they find. Multiplayer
       mode can be either cooperative or PvP.
       Hosting your own Terraria server gives you control over the world, the players,
@@ -173,10 +167,9 @@ export const oneClickApps: OCA[] = [
   {
     name: 'TF2',
     description: `Team Fortress 2 is a team-based multiplayer first-person shooter.
-      In TF2, you and your team choose from 9 unique classes and play against
-      an enemy team in a variety of game modes. These modes include capture the
-      flag, king of the hill, and even a battle pitting your team against a
-      robotic horde. Setting up a personal game server puts you in control of
+      In TF2, you and your team choose from a number of hero classes and different game modes, 
+      ensuring a unique in-game experience every match.
+      Setting up a personal game server puts you in control of
       what game modes and maps you use, as well as a variety of other settings
       to customize your experience.`,
     summary: `Choose from 9 unique classes in this highly original FPS. Compete against
@@ -194,8 +187,7 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'WooCommerce',
-    description: `WooCommerce is an open source eCommerce platform built to integrate with
-      WordPress. You can use WooCommerce to securely sell both digital and
+    description: `With WooCommerce, you can securely sell both digital and
       physical goods, and take payments via major credit cards, bank transfers,
       PayPal, and other providers like Stripe. With more than 300 extensions to
       choose from, WooCommerce is extremely flexible.`,
@@ -223,7 +215,7 @@ export const oneClickApps: OCA[] = [
       characteristics make them a great choice for your applications. Upload your
       existing MERN website code to your new Linode, or use MERN's scaffolding tool
       to start writing new web applications on the Linode.`,
-    summary: `Build production-ready universal apps with the MERN stack: MongoDB, Express, React, and Node.js.`,
+    summary: `Build production-ready apps with the MERN stack: MongoDB, Express, React, and Node.js.`,
     related_guides: [
       {
         title: 'Deploy a MERN Stack with One-Click Apps',
@@ -235,12 +227,12 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'OpenVPN',
-    description: `OpenVPN is a widely trusted, free, and open-source virtual private network
-      (VPN) application. OpenVPN creates network tunnels between groups of
+    description: `OpenVPN is a widely trusted, free, and open-source virtual private network 
+    application. OpenVPN creates network tunnels between groups of
       computers that are not on the same local network, and it uses OpenSSL
       to encrypt your traffic.`,
-    summary: `Widely trusted, free, and open-source virtual private network (VPN)
-      application. OpenVPN securely connects your computer to your servers,
+    summary: `Open-source virtual private network (VPN) application. 
+      OpenVPN securely connects your computer to your servers,
       or to the public Internet.`,
     related_guides: [
       {
@@ -288,10 +280,7 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'WireGuard',
-    description: `WireGuard is a simple, fast, and modern virtual private network (VPN) which utilizes
-      state-of-the-art cryptography. It aims to be faster and leaner than other VPN protocols
-      such as OpenVPN and IPSec, and it has a much smaller source code footprint.
-      Configuring WireGuard is as simple as configuring SSH. A connection is established by an
+    description: `Configuring WireGuard is as simple as configuring SSH. A connection is established by an
       exchange of public keys between server and client, and only a client whose public key is
       present in the server's configuration file is considered authorized. WireGuard sets up
       standard network interfaces which behave similarly to other common network interfaces,
@@ -330,11 +319,11 @@ export const oneClickApps: OCA[] = [
   {
     name: 'WordPress',
     description: `With 60 million users around the globe, WordPress is the industry standard
-      for content-focused websites such as blogs, news sites, and personal
-      websites. With a focus on best in class usability and flexibility,
+      for custom websites such as blogs, news sites, personal
+      websites, and anything in-between. With a focus on best in class usability and flexibility,
       you can have a customized website up and running in minutes.`,
     summary:
-      'Flexible, open source content management system (CMS) for blogs, news sites, and other content-focused websites.',
+      'Flexible, open source content management system (CMS) for content-focused websites of any kind.',
     related_guides: [
       {
         title: 'Deploy WordPress with One-Click Apps',


### PR DESCRIPTION
ARK: removed duplicative language from first sentence in description, left it in the summary
CS:GO: removed duplicative language from the first sentence in the description, left it in the summary
GitLab: i think there is no duplicative language and this looks fine
Drupal: removed duplicative language from the summary, as the summary was a bit lengthy. left similar language in the description
LAMP: removed duplicative language from the summary and left it in the description. you could argue that there is still some overlap there, but I think it is okay based on the description digging deeper into the items mentioned in the summary.
Rust: removed duplicative language from description, left it in summary.
Terraria: removed duplicative language from description, left in summary. Description is a little shorter, but I think it should be fine.
TF2: made the language around classes and game modes less specific in the description but left details in the summary. 
WooCommerce: took duplicative language out of the description and left it in the summary.
MERN: remover 'universal' from the summary, but otherwise left it the same. i think that it's a little long, but the technologies associated with MERN are probably not as high-touch as the technologies associated with LAMP, so the additional context is nice for users.
OpenVPN: this one was tricky, as there's not much to work off of. the first sentence in the description is a little duplicative, but generally still adds some context the summary does not. I would welcome suggestions on this one if it does not look okay as is.
Minecraft: going to leave this as is. the description is a little lengthy, but i think it adds value and sells the game.
WireGuard: deleted first two sentences of description that were effectively a copy of the summary. rest looks good to me.
~ there is a duplicate of WooCommerce second from the bottom that was addressed at the top. this should be removed.
WordPress: this was another tricky one, as the language was quite recursive. changed some things around in both- content-focused websites is now solely used in the summary, and the description of what that means exactly is exclusive to the description section. would welcome feedback on this change for sure.

## Description

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
